### PR TITLE
Auto-color axon lines using turbo colormap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ classifiers = [
 dependencies = [
     "napari>=0.5.0",
     "numpy>=1.24",
+    "matplotlib",
     "brainglobe-atlasapi>=2.0",
+    "pyarrow>=14.0",
+    "duckdb>=0.9",
+    "pandas>=2.0",
+    "qtpy>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/napari_swc_viewer/_reader.py
+++ b/src/napari_swc_viewer/_reader.py
@@ -1,0 +1,252 @@
+"""napari reader hook implementation for SWC and Parquet files.
+
+This module provides napari reader hooks for:
+1. SWC files - rendered as shapes (lines) or points
+2. Parquet files - rendered with neurons as shapes layers
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+import numpy as np
+
+from .swc import NodeType, parse_swc
+
+if TYPE_CHECKING:
+    from napari.types import LayerDataTuple
+
+
+def napari_get_reader(
+    path: str | list[str],
+) -> Callable[[str | list[str]], list[LayerDataTuple]] | None:
+    """Return a reader function if the path is a supported file type.
+
+    Parameters
+    ----------
+    path : str or list of str
+        Path(s) to the file(s) to read.
+
+    Returns
+    -------
+    callable or None
+        Reader function if the file type is supported, None otherwise.
+    """
+    if isinstance(path, list):
+        # Handle multiple files
+        paths = [Path(p) for p in path]
+        suffixes = {p.suffix.lower() for p in paths}
+
+        if suffixes == {".swc"}:
+            return read_swc_files
+        if suffixes == {".parquet"}:
+            return read_parquet_file
+
+        return None
+
+    path = Path(path)
+    suffix = path.suffix.lower()
+
+    if suffix == ".swc":
+        return read_swc_file
+    if suffix == ".parquet":
+        return read_parquet_file
+
+    return None
+
+
+def read_swc_file(path: str | list[str]) -> list[LayerDataTuple]:
+    """Read a single SWC file and return napari layer data.
+
+    Parameters
+    ----------
+    path : str or list of str
+        Path to the SWC file.
+
+    Returns
+    -------
+    list of LayerDataTuple
+        List of layer data tuples for napari.
+    """
+    if isinstance(path, list):
+        path = path[0]
+
+    filepath = Path(path)
+    swc_data = parse_swc(filepath)
+
+    # Build lines from parent-child relationships
+    lines = []
+    id_to_idx = {node_id: idx for idx, node_id in enumerate(swc_data.ids)}
+
+    for idx, parent_id in enumerate(swc_data.parents):
+        if parent_id in id_to_idx:
+            parent_idx = id_to_idx[parent_id]
+            lines.append([swc_data.coords[parent_idx], swc_data.coords[idx]])
+
+    if not lines:
+        # Fall back to points if no lines can be constructed
+        return [
+            (
+                swc_data.coords,
+                {
+                    "size": 2,
+                    "face_color": "cyan",
+                    "name": filepath.stem,
+                },
+                "points",
+            )
+        ]
+
+    # Create shapes layer with lines
+    layer_data: LayerDataTuple = (
+        lines,
+        {
+            "shape_type": "line",
+            "edge_width": 1,
+            "edge_color": "cyan",
+            "name": filepath.stem,
+        },
+        "shapes",
+    )
+
+    return [layer_data]
+
+
+def read_swc_files(paths: str | list[str]) -> list[LayerDataTuple]:
+    """Read multiple SWC files and return napari layer data.
+
+    Parameters
+    ----------
+    paths : str or list of str
+        Paths to the SWC files.
+
+    Returns
+    -------
+    list of LayerDataTuple
+        List of layer data tuples for napari.
+    """
+    if isinstance(paths, str):
+        paths = [paths]
+
+    layers = []
+    for path in paths:
+        layers.extend(read_swc_file(path))
+
+    return layers
+
+
+def read_parquet_file(path: str | list[str]) -> list[LayerDataTuple]:
+    """Read a Parquet file with neuron data and return napari layer data.
+
+    This function reads the Parquet file and creates a points layer
+    showing all soma locations. The full neuron data can be explored
+    using the NeuronViewerWidget.
+
+    Parameters
+    ----------
+    path : str or list of str
+        Path to the Parquet file.
+
+    Returns
+    -------
+    list of LayerDataTuple
+        List of layer data tuples for napari.
+    """
+    if isinstance(path, list):
+        path = path[0]
+
+    filepath = Path(path)
+
+    from .db import NeuronDatabase
+
+    try:
+        db = NeuronDatabase(filepath)
+    except FileNotFoundError:
+        return []
+
+    # Get soma locations for initial display
+    somas = db.get_soma_locations()
+    db.close()
+
+    if somas.empty:
+        return []
+
+    coords = somas[["x", "y", "z"]].values
+
+    # Create points layer for somas
+    layer_data: LayerDataTuple = (
+        coords,
+        {
+            "size": 10,
+            "face_color": "red",
+            "name": f"Somas: {filepath.stem}",
+            "properties": {
+                "file_id": somas["file_id"].tolist(),
+                "neuron_id": somas["neuron_id"].tolist(),
+                "region": somas["region_acronym"].tolist(),
+            },
+        },
+        "points",
+    )
+
+    return [layer_data]
+
+
+def swc_to_shapes_data(
+    path: str | Path,
+    color_by_type: bool = True,
+) -> tuple[list[np.ndarray], dict[str, Any]]:
+    """Convert SWC file to shapes layer data with optional coloring.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the SWC file.
+    color_by_type : bool, default=True
+        If True, color lines by node type.
+
+    Returns
+    -------
+    tuple
+        (lines, properties) for napari shapes layer.
+    """
+    swc_data = parse_swc(path)
+
+    # Build lines and colors
+    lines = []
+    colors = []
+    id_to_idx = {node_id: idx for idx, node_id in enumerate(swc_data.ids)}
+
+    # Node type colors
+    type_colors = {
+        NodeType.SOMA: "red",
+        NodeType.AXON: "blue",
+        NodeType.BASAL_DENDRITE: "green",
+        NodeType.APICAL_DENDRITE: "yellow",
+        NodeType.UNDEFINED: "gray",
+        NodeType.CUSTOM: "purple",
+        NodeType.UNSPECIFIED_NEURITE: "orange",
+        NodeType.GLIA: "pink",
+    }
+
+    for idx, parent_id in enumerate(swc_data.parents):
+        if parent_id in id_to_idx:
+            parent_idx = id_to_idx[parent_id]
+            lines.append(
+                np.array([swc_data.coords[parent_idx], swc_data.coords[idx]])
+            )
+            if color_by_type:
+                node_type = swc_data.types[idx]
+                colors.append(type_colors.get(node_type, "gray"))
+            else:
+                colors.append("cyan")
+
+    properties = {
+        "shape_type": "line",
+        "edge_width": 1,
+        "edge_color": colors if color_by_type else "cyan",
+        "name": Path(path).stem,
+    }
+
+    return lines, properties

--- a/src/napari_swc_viewer/db.py
+++ b/src/napari_swc_viewer/db.py
@@ -1,0 +1,330 @@
+"""DuckDB query interface for neuron data.
+
+This module provides a NeuronDatabase class for efficient querying of
+neuron data stored in Parquet format using DuckDB.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import duckdb
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+class NeuronDatabase:
+    """DuckDB-based interface for querying neuron data from Parquet files.
+
+    Parameters
+    ----------
+    parquet_path : Path or str
+        Path to the Parquet file containing neuron data.
+
+    Examples
+    --------
+    >>> db = NeuronDatabase("neurons.parquet")
+    >>> # Get all neurons in a specific region
+    >>> neurons = db.get_neurons_by_region(["VISp"])
+    >>> # Get soma locations for all neurons
+    >>> somas = db.get_soma_locations()
+    """
+
+    def __init__(self, parquet_path: Path | str):
+        self.parquet_path = Path(parquet_path)
+        if not self.parquet_path.exists():
+            raise FileNotFoundError(f"Parquet file not found: {self.parquet_path}")
+
+        self.conn = duckdb.connect()
+        self._setup_view()
+
+    def _setup_view(self) -> None:
+        """Create a view for the Parquet file."""
+        path_str = str(self.parquet_path).replace("\\", "/")
+        self.conn.execute(
+            f"CREATE OR REPLACE VIEW neurons AS SELECT * FROM read_parquet('{path_str}')"
+        )
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self.conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def get_neurons_by_region(
+        self,
+        region_acronyms: list[str],
+        include_children: bool = False,
+    ) -> pd.DataFrame:
+        """Get neurons that have nodes in the specified regions.
+
+        Parameters
+        ----------
+        region_acronyms : list[str]
+            List of region acronyms to query (e.g., ["VISp", "VISl"]).
+        include_children : bool, default=False
+            If True, include child regions in the query.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns: file_id, neuron_id, subject
+        """
+        if not region_acronyms:
+            return pd.DataFrame(columns=["file_id", "neuron_id", "subject"])
+
+        placeholders = ", ".join(["?"] * len(region_acronyms))
+        query = f"""
+            SELECT DISTINCT file_id, neuron_id, subject
+            FROM neurons
+            WHERE region_acronym IN ({placeholders})
+            ORDER BY file_id
+        """
+        return self.conn.execute(query, region_acronyms).fetchdf()
+
+    def get_neurons_by_region_id(
+        self,
+        region_ids: list[int],
+    ) -> pd.DataFrame:
+        """Get neurons that have nodes in the specified region IDs.
+
+        Parameters
+        ----------
+        region_ids : list[int]
+            List of Allen CCF region IDs.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns: file_id, neuron_id, subject
+        """
+        if not region_ids:
+            return pd.DataFrame(columns=["file_id", "neuron_id", "subject"])
+
+        placeholders = ", ".join(["?"] * len(region_ids))
+        query = f"""
+            SELECT DISTINCT file_id, neuron_id, subject
+            FROM neurons
+            WHERE region_id IN ({placeholders})
+            ORDER BY file_id
+        """
+        return self.conn.execute(query, region_ids).fetchdf()
+
+    def get_unique_regions(self) -> pd.DataFrame:
+        """Get all unique regions in the dataset with counts.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns: region_id, region_acronym, region_name, node_count
+        """
+        query = """
+            SELECT
+                region_id,
+                region_acronym,
+                MAX(region_name) as region_name,
+                COUNT(*) as node_count
+            FROM neurons
+            WHERE region_id > 0
+            GROUP BY region_id, region_acronym
+            ORDER BY node_count DESC
+        """
+        return self.conn.execute(query).fetchdf()
+
+    def get_soma_locations(
+        self,
+        file_ids: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """Get soma locations for neurons.
+
+        Parameters
+        ----------
+        file_ids : list[str], optional
+            Filter to specific files. If None, return all somas.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns: file_id, neuron_id, x, y, z, region_acronym
+        """
+        if file_ids:
+            placeholders = ", ".join(["?"] * len(file_ids))
+            query = f"""
+                SELECT
+                    file_id, neuron_id,
+                    AVG(x) as x, AVG(y) as y, AVG(z) as z,
+                    MAX(region_acronym) as region_acronym
+                FROM neurons
+                WHERE type = 1 AND file_id IN ({placeholders})
+                GROUP BY file_id, neuron_id
+                ORDER BY file_id
+            """
+            return self.conn.execute(query, file_ids).fetchdf()
+        else:
+            query = """
+                SELECT
+                    file_id, neuron_id,
+                    AVG(x) as x, AVG(y) as y, AVG(z) as z,
+                    MAX(region_acronym) as region_acronym
+                FROM neurons
+                WHERE type = 1
+                GROUP BY file_id, neuron_id
+                ORDER BY file_id
+            """
+            return self.conn.execute(query).fetchdf()
+
+    def get_neurons_for_rendering(
+        self,
+        file_ids: list[str],
+    ) -> pd.DataFrame:
+        """Get full neuron data for rendering.
+
+        Parameters
+        ----------
+        file_ids : list[str]
+            List of file IDs to retrieve.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with all neuron node data for the specified files.
+        """
+        if not file_ids:
+            return pd.DataFrame()
+
+        placeholders = ", ".join(["?"] * len(file_ids))
+        query = f"""
+            SELECT *
+            FROM neurons
+            WHERE file_id IN ({placeholders})
+            ORDER BY file_id, node_id
+        """
+        return self.conn.execute(query, file_ids).fetchdf()
+
+    def get_neuron_lines(
+        self,
+        file_id: str,
+    ) -> tuple[NDArray[np.float64], NDArray[np.int32]]:
+        """Get line segments for a single neuron.
+
+        Parameters
+        ----------
+        file_id : str
+            The file ID of the neuron.
+
+        Returns
+        -------
+        tuple[NDArray, NDArray]
+            (vertices, edges) where vertices is (N, 3) coordinates and
+            edges is (M, 2) indices into vertices.
+        """
+        query = """
+            SELECT node_id, x, y, z, parent_id
+            FROM neurons
+            WHERE file_id = ?
+            ORDER BY node_id
+        """
+        df = self.conn.execute(query, [file_id]).fetchdf()
+
+        if df.empty:
+            return np.array([]).reshape(0, 3), np.array([]).reshape(0, 2)
+
+        # Build coordinate array
+        coords = df[["x", "y", "z"]].values.astype(np.float64)
+
+        # Build node_id to index mapping
+        node_ids = df["node_id"].values
+        id_to_idx = {nid: idx for idx, nid in enumerate(node_ids)}
+
+        # Build edges
+        edges = []
+        for idx, parent_id in enumerate(df["parent_id"].values):
+            if parent_id in id_to_idx:
+                parent_idx = id_to_idx[parent_id]
+                edges.append([parent_idx, idx])
+
+        edges = np.array(edges, dtype=np.int32) if edges else np.array([]).reshape(0, 2)
+
+        return coords, edges
+
+    def get_statistics(self) -> dict:
+        """Get summary statistics for the database.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys: n_nodes, n_files, n_subjects, n_regions
+        """
+        stats = {}
+
+        result = self.conn.execute("SELECT COUNT(*) FROM neurons").fetchone()
+        stats["n_nodes"] = result[0]
+
+        result = self.conn.execute(
+            "SELECT COUNT(DISTINCT file_id) FROM neurons"
+        ).fetchone()
+        stats["n_files"] = result[0]
+
+        result = self.conn.execute(
+            "SELECT COUNT(DISTINCT subject) FROM neurons"
+        ).fetchone()
+        stats["n_subjects"] = result[0]
+
+        result = self.conn.execute(
+            "SELECT COUNT(DISTINCT region_id) FROM neurons WHERE region_id > 0"
+        ).fetchone()
+        stats["n_regions"] = result[0]
+
+        return stats
+
+    def get_region_neuron_counts(self) -> pd.DataFrame:
+        """Get neuron counts per region.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns: region_acronym, region_name, neuron_count
+        """
+        query = """
+            SELECT
+                region_acronym,
+                MAX(region_name) as region_name,
+                COUNT(DISTINCT file_id) as neuron_count
+            FROM neurons
+            WHERE region_acronym != ''
+            GROUP BY region_acronym
+            ORDER BY neuron_count DESC
+        """
+        return self.conn.execute(query).fetchdf()
+
+    def query(self, sql: str, params: list | None = None) -> pd.DataFrame:
+        """Execute a custom SQL query.
+
+        Parameters
+        ----------
+        sql : str
+            SQL query string. Use 'neurons' as the table name.
+        params : list, optional
+            Query parameters for placeholders.
+
+        Returns
+        -------
+        pd.DataFrame
+            Query results as a DataFrame.
+
+        Examples
+        --------
+        >>> db.query("SELECT * FROM neurons WHERE type = 2 LIMIT 10")
+        >>> db.query("SELECT * FROM neurons WHERE file_id = ?", ["file.swc"])
+        """
+        if params:
+            return self.conn.execute(sql, params).fetchdf()
+        return self.conn.execute(sql).fetchdf()

--- a/src/napari_swc_viewer/napari.yaml
+++ b/src/napari_swc_viewer/napari.yaml
@@ -1,6 +1,21 @@
 name: napari-swc-viewer
 display_name: SWC Viewer
 contributions:
-  commands: []
-  readers: []
-  widgets: []
+  commands:
+    - id: napari-swc-viewer.get_reader
+      python_name: napari_swc_viewer._reader:napari_get_reader
+      title: Open SWC or Parquet file
+    - id: napari-swc-viewer.neuron_viewer
+      python_name: napari_swc_viewer.widgets:NeuronViewerWidget
+      title: Neuron Viewer
+
+  readers:
+    - command: napari-swc-viewer.get_reader
+      accepts_directories: false
+      filename_patterns:
+        - "*.swc"
+        - "*.parquet"
+
+  widgets:
+    - command: napari-swc-viewer.neuron_viewer
+      display_name: Neuron Viewer

--- a/src/napari_swc_viewer/parquet.py
+++ b/src/napari_swc_viewer/parquet.py
@@ -1,0 +1,422 @@
+"""Parquet schema and SWC-to-Parquet conversion with brain region annotation.
+
+This module provides functionality to:
+1. Define the Parquet schema for annotated neuron data
+2. Convert SWC files to Parquet format with region annotations
+3. Batch process multiple SWC files with parallel processing
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .region import (
+    build_region_lookup,
+    get_region_ids_vectorized,
+    setup_allen_sdk,
+)
+from .swc import parse_swc
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+# Parquet schema for annotated neuron data
+NEURON_SCHEMA = pa.schema(
+    [
+        pa.field("file_id", pa.string()),  # Source SWC filename
+        pa.field("node_id", pa.int32()),  # Node ID within file
+        pa.field("type", pa.int32()),  # Node type (1=soma, 2=axon, etc.)
+        pa.field("x", pa.float64()),  # X coordinate (microns)
+        pa.field("y", pa.float64()),  # Y coordinate (microns)
+        pa.field("z", pa.float64()),  # Z coordinate (microns)
+        pa.field("radius", pa.float64()),  # Node radius
+        pa.field("parent_id", pa.int32()),  # Parent node ID
+        pa.field("region_id", pa.int32()),  # Allen CCF region ID
+        pa.field("region_name", pa.string()),  # Full region name
+        pa.field("region_acronym", pa.string()),  # e.g., "VISp"
+        pa.field("subject", pa.string()),  # Subject ID (from filename)
+        pa.field("neuron_id", pa.string()),  # Neuron identifier (from filename)
+    ]
+)
+
+
+def parse_filename_metadata(filename: str) -> dict[str, str]:
+    """Extract subject and neuron ID from SWC filename.
+
+    Attempts to parse common naming conventions:
+    - BIL format: {neuron_id}_{subject}_{slice}-X{x}-Y{y}.swc
+    - Simple format: {subject}_{suffix}.swc
+
+    Parameters
+    ----------
+    filename : str
+        The SWC filename (without path).
+
+    Returns
+    -------
+    dict[str, str]
+        Dictionary with 'subject' and 'neuron_id' keys.
+    """
+    stem = Path(filename).stem
+
+    # Try BIL format: 1059281710_18462_6029-X10270-Y8859
+    bil_match = re.match(r"(\d+)_(\d+)_", stem)
+    if bil_match:
+        return {
+            "neuron_id": bil_match.group(1),
+            "subject": bil_match.group(2),
+        }
+
+    # Try format: H19.03.315.11.12.01.01_1024476468_m
+    h19_match = re.match(r"(H\d+\.\d+\.\d+\.\d+\.\d+\.\d+\.\d+)_(\d+)", stem)
+    if h19_match:
+        return {
+            "subject": h19_match.group(1),
+            "neuron_id": h19_match.group(2),
+        }
+
+    # Fallback: use whole stem as both
+    return {
+        "subject": stem,
+        "neuron_id": stem,
+    }
+
+
+def swc_to_annotated_rows(
+    swc_path: Path,
+    annotation_volume: NDArray[np.int32],
+    structure_tree,
+    region_lookup: dict[int, dict],
+    resolution: int = 25,
+) -> list[dict]:
+    """Convert a single SWC file to annotated row dictionaries.
+
+    Parameters
+    ----------
+    swc_path : Path
+        Path to the SWC file.
+    annotation_volume : NDArray[np.int32]
+        3D annotation volume from Allen SDK.
+    structure_tree : StructureTree
+        Allen SDK structure tree.
+    region_lookup : dict[int, dict]
+        Precomputed mapping from region ID to region info.
+    resolution : int, default=25
+        Resolution of the annotation volume in microns.
+
+    Returns
+    -------
+    list[dict]
+        List of row dictionaries matching NEURON_SCHEMA.
+    """
+    swc_data = parse_swc(swc_path)
+    filename = swc_path.name
+    metadata = parse_filename_metadata(filename)
+
+    # Get region IDs for all coordinates (vectorized)
+    region_ids = get_region_ids_vectorized(
+        swc_data.coords, annotation_volume, resolution
+    )
+
+    rows = []
+    for i in range(swc_data.n_nodes):
+        region_id = int(region_ids[i])
+        region_info = region_lookup.get(region_id, {})
+
+        rows.append(
+            {
+                "file_id": filename,
+                "node_id": int(swc_data.ids[i]),
+                "type": int(swc_data.types[i]),
+                "x": float(swc_data.coords[i, 0]),
+                "y": float(swc_data.coords[i, 1]),
+                "z": float(swc_data.coords[i, 2]),
+                "radius": float(swc_data.radii[i]),
+                "parent_id": int(swc_data.parents[i]),
+                "region_id": region_id,
+                "region_name": region_info.get("name", ""),
+                "region_acronym": region_info.get("acronym", ""),
+                "subject": metadata["subject"],
+                "neuron_id": metadata["neuron_id"],
+            }
+        )
+
+    return rows
+
+
+def _process_single_swc(args: tuple) -> list[dict]:
+    """Worker function for parallel processing. Handles its own Allen SDK setup."""
+    swc_path, resolution, cache_dir = args
+
+    # Each worker loads its own copy of Allen SDK data
+    _, annotation_volume, structure_tree = setup_allen_sdk(resolution, cache_dir)
+    region_lookup = build_region_lookup(structure_tree)
+
+    return swc_to_annotated_rows(
+        swc_path, annotation_volume, structure_tree, region_lookup, resolution
+    )
+
+
+def discover_swc_files(input_path: Path, recursive: bool = True) -> list[Path]:
+    """Discover SWC files in a directory.
+
+    Parameters
+    ----------
+    input_path : Path
+        Path to a directory or single SWC file.
+    recursive : bool, default=True
+        If True, search subdirectories recursively.
+
+    Returns
+    -------
+    list[Path]
+        List of paths to SWC files.
+    """
+    input_path = Path(input_path)
+
+    if input_path.is_file():
+        if input_path.suffix.lower() == ".swc":
+            return [input_path]
+        return []
+
+    if recursive:
+        return sorted(input_path.rglob("*.swc"))
+    return sorted(input_path.glob("*.swc"))
+
+
+def swc_files_to_parquet(
+    input_path: Path | str,
+    output_path: Path | str,
+    resolution: int = 25,
+    cache_dir: Path | str | None = None,
+    recursive: bool = True,
+    n_workers: int = 1,
+    batch_size: int = 100,
+) -> int:
+    """Convert SWC files to a single annotated Parquet file.
+
+    Parameters
+    ----------
+    input_path : Path or str
+        Path to a directory of SWC files or a single SWC file.
+    output_path : Path or str
+        Path for the output Parquet file.
+    resolution : int, default=25
+        Allen CCF resolution in microns.
+    cache_dir : Path or str, optional
+        Directory to cache Allen SDK data.
+    recursive : bool, default=True
+        If True, search subdirectories recursively.
+    n_workers : int, default=1
+        Number of parallel workers. Use 1 for serial processing.
+    batch_size : int, default=100
+        Number of files to process before writing to disk.
+
+    Returns
+    -------
+    int
+        Number of SWC files processed.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+
+    # Discover SWC files
+    swc_files = discover_swc_files(input_path, recursive)
+    if not swc_files:
+        logger.warning(f"No SWC files found in {input_path}")
+        return 0
+
+    logger.info(f"Found {len(swc_files)} SWC files to process")
+
+    # Set up Allen SDK (for serial processing or building lookup)
+    _, annotation_volume, structure_tree = setup_allen_sdk(resolution, cache_dir)
+    region_lookup = build_region_lookup(structure_tree)
+
+    all_rows: list[dict] = []
+    processed = 0
+
+    if n_workers > 1:
+        # Parallel processing
+        args_list = [
+            (swc_path, resolution, str(cache_dir) if cache_dir else None)
+            for swc_path in swc_files
+        ]
+
+        with ProcessPoolExecutor(max_workers=n_workers) as executor:
+            futures = {
+                executor.submit(_process_single_swc, args): args[0]
+                for args in args_list
+            }
+
+            for future in as_completed(futures):
+                swc_path = futures[future]
+                try:
+                    rows = future.result()
+                    all_rows.extend(rows)
+                    processed += 1
+
+                    if processed % 10 == 0:
+                        logger.info(f"Processed {processed}/{len(swc_files)} files")
+
+                except Exception as e:
+                    logger.error(f"Error processing {swc_path}: {e}")
+    else:
+        # Serial processing
+        for i, swc_path in enumerate(swc_files):
+            try:
+                rows = swc_to_annotated_rows(
+                    swc_path,
+                    annotation_volume,
+                    structure_tree,
+                    region_lookup,
+                    resolution,
+                )
+                all_rows.extend(rows)
+                processed += 1
+
+                if processed % 10 == 0:
+                    logger.info(f"Processed {processed}/{len(swc_files)} files")
+
+            except Exception as e:
+                logger.error(f"Error processing {swc_path}: {e}")
+
+    # Write to Parquet
+    if all_rows:
+        table = pa.Table.from_pylist(all_rows, schema=NEURON_SCHEMA)
+        pq.write_table(table, output_path, compression="snappy")
+        logger.info(
+            f"Wrote {len(all_rows)} rows from {processed} files to {output_path}"
+        )
+
+    return processed
+
+
+def append_to_parquet(
+    existing_path: Path | str,
+    new_swc_path: Path | str,
+    resolution: int = 25,
+    cache_dir: Path | str | None = None,
+) -> int:
+    """Append new SWC files to an existing Parquet file.
+
+    Parameters
+    ----------
+    existing_path : Path or str
+        Path to existing Parquet file.
+    new_swc_path : Path or str
+        Path to new SWC file or directory.
+    resolution : int, default=25
+        Allen CCF resolution in microns.
+    cache_dir : Path or str, optional
+        Directory to cache Allen SDK data.
+
+    Returns
+    -------
+    int
+        Number of new files appended.
+    """
+    existing_path = Path(existing_path)
+    new_swc_path = Path(new_swc_path)
+
+    # Load existing data
+    existing_table = pq.read_table(existing_path)
+    existing_files = set(existing_table.column("file_id").to_pylist())
+
+    # Discover new files
+    new_files = discover_swc_files(new_swc_path)
+    new_files = [f for f in new_files if f.name not in existing_files]
+
+    if not new_files:
+        logger.info("No new files to append")
+        return 0
+
+    # Process new files
+    _, annotation_volume, structure_tree = setup_allen_sdk(resolution, cache_dir)
+    region_lookup = build_region_lookup(structure_tree)
+
+    new_rows: list[dict] = []
+    for swc_path in new_files:
+        try:
+            rows = swc_to_annotated_rows(
+                swc_path,
+                annotation_volume,
+                structure_tree,
+                region_lookup,
+                resolution,
+            )
+            new_rows.extend(rows)
+        except Exception as e:
+            logger.error(f"Error processing {swc_path}: {e}")
+
+    if new_rows:
+        new_table = pa.Table.from_pylist(new_rows, schema=NEURON_SCHEMA)
+        combined = pa.concat_tables([existing_table, new_table])
+        pq.write_table(combined, existing_path, compression="snappy")
+        logger.info(f"Appended {len(new_files)} files to {existing_path}")
+
+    return len(new_files)
+
+
+def get_parquet_summary(parquet_path: Path | str) -> dict:
+    """Get summary statistics for a Parquet file.
+
+    Parameters
+    ----------
+    parquet_path : Path or str
+        Path to the Parquet file.
+
+    Returns
+    -------
+    dict
+        Summary with keys: n_rows, n_files, n_subjects, n_regions, regions
+    """
+    import duckdb
+
+    conn = duckdb.connect()
+    path_str = str(parquet_path)
+
+    stats = {}
+
+    # Row count
+    result = conn.execute(
+        f"SELECT COUNT(*) as n FROM read_parquet('{path_str}')"
+    ).fetchone()
+    stats["n_rows"] = result[0]
+
+    # File count
+    result = conn.execute(
+        f"SELECT COUNT(DISTINCT file_id) as n FROM read_parquet('{path_str}')"
+    ).fetchone()
+    stats["n_files"] = result[0]
+
+    # Subject count
+    result = conn.execute(
+        f"SELECT COUNT(DISTINCT subject) as n FROM read_parquet('{path_str}')"
+    ).fetchone()
+    stats["n_subjects"] = result[0]
+
+    # Region count and list
+    result = conn.execute(
+        f"""
+        SELECT region_acronym, COUNT(*) as n
+        FROM read_parquet('{path_str}')
+        WHERE region_acronym != ''
+        GROUP BY region_acronym
+        ORDER BY n DESC
+        """
+    ).fetchall()
+    stats["n_regions"] = len(result)
+    stats["regions"] = {row[0]: row[1] for row in result}
+
+    conn.close()
+    return stats

--- a/src/napari_swc_viewer/region.py
+++ b/src/napari_swc_viewer/region.py
@@ -1,0 +1,367 @@
+"""Brain region mapping using BrainGlobe Atlas API.
+
+This module provides functionality to:
+1. Load annotation volumes from BrainGlobe atlases
+2. Map coordinates to brain regions using the Allen CCF
+3. Get hierarchical region information from the structure tree
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from brainglobe_atlasapi import BrainGlobeAtlas
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+# Allen CCF resolution options in microns
+RESOLUTIONS = [10, 25, 50, 100]
+
+# Mapping from resolution to atlas name
+ATLAS_NAMES = {
+    10: "allen_mouse_10um",
+    25: "allen_mouse_25um",
+    50: "allen_mouse_50um",
+    100: "allen_mouse_100um",
+}
+
+
+def setup_allen_sdk(
+    resolution: int = 25,
+    cache_dir: Path | str | None = None,
+) -> tuple:
+    """Load annotation volume and structure data using BrainGlobe Atlas API.
+
+    This function provides a compatible interface with the original Allen SDK
+    setup, but uses BrainGlobe Atlas API which has better dependency compatibility.
+
+    Parameters
+    ----------
+    resolution : int, default=25
+        Resolution in microns. Must be one of [10, 25, 50, 100].
+    cache_dir : Path or str, optional
+        Not used (BrainGlobe manages its own cache). Kept for API compatibility.
+
+    Returns
+    -------
+    tuple
+        (atlas, annotation_volume, structure_tree) where:
+        - atlas: BrainGlobeAtlas instance
+        - annotation_volume: 3D array of region IDs
+        - structure_tree: BrainGlobeStructureTree wrapper for region metadata
+    """
+    if resolution not in RESOLUTIONS:
+        raise ValueError(f"Resolution must be one of {RESOLUTIONS}, got {resolution}")
+
+    atlas_name = ATLAS_NAMES[resolution]
+    logger.info(f"Loading BrainGlobe atlas: {atlas_name}")
+
+    atlas = BrainGlobeAtlas(atlas_name)
+    annotation_volume = atlas.annotation
+
+    # Create a structure tree wrapper that provides compatible interface
+    structure_tree = BrainGlobeStructureTree(atlas)
+
+    logger.info(
+        f"Annotation volume shape: {annotation_volume.shape}, "
+        f"Structure tree loaded with {len(atlas.structures)} structures"
+    )
+
+    return atlas, annotation_volume, structure_tree
+
+
+class BrainGlobeStructureTree:
+    """Wrapper around BrainGlobe atlas structures to provide Allen SDK-like interface."""
+
+    def __init__(self, atlas: BrainGlobeAtlas):
+        self.atlas = atlas
+        self._structures_by_id: dict[int, dict] = {}
+        self._children: dict[int, list[int]] = {}
+
+        # Build lookup tables - extract only the fields we need without triggering mesh loading
+        for key, struct in atlas.structures.items():
+            if isinstance(key, int):
+                # Manually extract fields to avoid triggering mesh loading via dict()
+                struct_dict = {
+                    "id": key,
+                    "name": struct["name"],
+                    "acronym": struct["acronym"],
+                    "structure_id_path": struct["structure_id_path"],
+                    "rgb_triplet": struct["rgb_triplet"],
+                }
+                # Safely get optional fields
+                if "parent_structure_id" in struct.data:
+                    struct_dict["parent_structure_id"] = struct["parent_structure_id"]
+                if "color_hex_triplet" in struct.data:
+                    struct_dict["color_hex_triplet"] = struct["color_hex_triplet"]
+
+                self._structures_by_id[key] = struct_dict
+
+                # Build children mapping
+                parent_id = struct_dict.get("parent_structure_id")
+                if parent_id is not None:
+                    if parent_id not in self._children:
+                        self._children[parent_id] = []
+                    self._children[parent_id].append(key)
+
+    def get_structures_by_id(self, ids: list[int]) -> list[dict]:
+        """Get structures by their IDs."""
+        return [self._structures_by_id[i] for i in ids if i in self._structures_by_id]
+
+    def get_structures_by_set_id(self, set_ids: list) -> list[dict]:
+        """Get all structures (set_ids is ignored, returns all)."""
+        return list(self._structures_by_id.values())
+
+    def child_ids(self, parent_ids: list[int]) -> list[list[int]]:
+        """Get child IDs for each parent ID."""
+        return [self._children.get(pid, []) for pid in parent_ids]
+
+
+@lru_cache(maxsize=4)
+def _get_cached_atlas(resolution: int = 25) -> tuple:
+    """Get cached atlas data. Returns same tuple as setup_allen_sdk."""
+    return setup_allen_sdk(resolution)
+
+
+def get_region_at_coords(
+    coords: NDArray[np.float64] | tuple[float, float, float],
+    annotation_volume: NDArray[np.int32],
+    structure_tree: BrainGlobeStructureTree,
+    resolution: int = 25,
+) -> dict | None:
+    """Get brain region information for a single coordinate.
+
+    Parameters
+    ----------
+    coords : array-like
+        Coordinate in microns (x, y, z) or PIR format matching the atlas.
+    annotation_volume : NDArray[np.int32]
+        3D annotation volume.
+    structure_tree : BrainGlobeStructureTree
+        Structure tree for region metadata.
+    resolution : int, default=25
+        Resolution of the annotation volume in microns.
+
+    Returns
+    -------
+    dict or None
+        Region info with keys: id, name, acronym, structure_id_path, color_hex_triplet
+        Returns None if coordinate is outside the brain.
+    """
+    # Convert microns to voxel indices
+    coords = np.asarray(coords)
+    voxel_coords = np.round(coords / resolution).astype(int)
+
+    # Check bounds
+    if not all(0 <= voxel_coords[i] < annotation_volume.shape[i] for i in range(3)):
+        return None
+
+    # Get region ID from annotation volume
+    region_id = annotation_volume[voxel_coords[0], voxel_coords[1], voxel_coords[2]]
+
+    if region_id == 0:
+        return None  # Outside brain
+
+    # Get region info from structure tree
+    structures = structure_tree.get_structures_by_id([int(region_id)])
+    if not structures:
+        return None
+
+    structure = structures[0]
+    return {
+        "id": int(region_id),
+        "name": structure.get("name", ""),
+        "acronym": structure.get("acronym", ""),
+        "structure_id_path": structure.get("structure_id_path", []),
+        "color_hex_triplet": structure.get("color_hex_triplet", ""),
+    }
+
+
+def get_regions_for_coords(
+    coords: NDArray[np.float64],
+    annotation_volume: NDArray[np.int32],
+    structure_tree: BrainGlobeStructureTree,
+    resolution: int = 25,
+) -> list[dict | None]:
+    """Get brain region information for multiple coordinates.
+
+    Parameters
+    ----------
+    coords : NDArray[np.float64]
+        Array of coordinates in microns, shape (N, 3).
+    annotation_volume : NDArray[np.int32]
+        3D annotation volume.
+    structure_tree : BrainGlobeStructureTree
+        Structure tree for region metadata.
+    resolution : int, default=25
+        Resolution of the annotation volume in microns.
+
+    Returns
+    -------
+    list[dict | None]
+        List of region info dicts, one per coordinate.
+    """
+    coords = np.atleast_2d(coords)
+    return [
+        get_region_at_coords(coord, annotation_volume, structure_tree, resolution)
+        for coord in coords
+    ]
+
+
+def get_region_ids_vectorized(
+    coords: NDArray[np.float64],
+    annotation_volume: NDArray[np.int32],
+    resolution: int = 25,
+) -> NDArray[np.int32]:
+    """Get region IDs for multiple coordinates using vectorized operations.
+
+    Parameters
+    ----------
+    coords : NDArray[np.float64]
+        Array of coordinates in microns, shape (N, 3).
+    annotation_volume : NDArray[np.int32]
+        3D annotation volume.
+    resolution : int, default=25
+        Resolution of the annotation volume in microns.
+
+    Returns
+    -------
+    NDArray[np.int32]
+        Array of region IDs, 0 for coordinates outside the brain.
+    """
+    coords = np.atleast_2d(coords)
+    n_coords = len(coords)
+
+    # Convert microns to voxel indices
+    voxel_coords = np.round(coords / resolution).astype(int)
+
+    # Initialize result with zeros (outside brain)
+    region_ids = np.zeros(n_coords, dtype=np.int32)
+
+    # Check bounds for all coordinates
+    in_bounds = np.all(
+        (voxel_coords >= 0) & (voxel_coords < np.array(annotation_volume.shape)),
+        axis=1,
+    )
+
+    # Get region IDs for in-bounds coordinates
+    valid_voxels = voxel_coords[in_bounds]
+    if len(valid_voxels) > 0:
+        region_ids[in_bounds] = annotation_volume[
+            valid_voxels[:, 0], valid_voxels[:, 1], valid_voxels[:, 2]
+        ]
+
+    return region_ids
+
+
+def build_region_lookup(structure_tree: BrainGlobeStructureTree) -> dict[int, dict]:
+    """Build a lookup table from region ID to region info.
+
+    Parameters
+    ----------
+    structure_tree : BrainGlobeStructureTree
+        Structure tree wrapper.
+
+    Returns
+    -------
+    dict[int, dict]
+        Mapping from region ID to dict with name, acronym, etc.
+    """
+    all_structures = structure_tree.get_structures_by_set_id([])
+    return {
+        s["id"]: {
+            "id": s["id"],
+            "name": s.get("name", ""),
+            "acronym": s.get("acronym", ""),
+            "structure_id_path": s.get("structure_id_path", []),
+            "color_hex_triplet": s.get("color_hex_triplet", ""),
+            "parent_structure_id": s.get("parent_structure_id"),
+        }
+        for s in all_structures
+    }
+
+
+def get_region_hierarchy(structure_tree: BrainGlobeStructureTree) -> dict[int, list[int]]:
+    """Get the full hierarchy of regions.
+
+    Parameters
+    ----------
+    structure_tree : BrainGlobeStructureTree
+        Structure tree wrapper.
+
+    Returns
+    -------
+    dict[int, list[int]]
+        Mapping from region ID to list of child region IDs.
+    """
+    return structure_tree._children.copy()
+
+
+def get_all_descendant_ids(
+    structure_tree: BrainGlobeStructureTree,
+    region_id: int,
+) -> set[int]:
+    """Get all descendant region IDs for a given region.
+
+    Parameters
+    ----------
+    structure_tree : BrainGlobeStructureTree
+        Structure tree wrapper.
+    region_id : int
+        The region ID to get descendants for.
+
+    Returns
+    -------
+    set[int]
+        Set of all descendant region IDs, including the input region.
+    """
+    descendants = {region_id}
+    children = structure_tree.child_ids([region_id])[0]
+
+    for child_id in children:
+        descendants.update(get_all_descendant_ids(structure_tree, child_id))
+
+    return descendants
+
+
+def get_structures_with_ancestors(
+    structure_tree: BrainGlobeStructureTree,
+    region_ids: list[int] | set[int],
+) -> dict[int, list[dict]]:
+    """Get structure info with full ancestor path for multiple regions.
+
+    Parameters
+    ----------
+    structure_tree : BrainGlobeStructureTree
+        Structure tree wrapper.
+    region_ids : list or set of int
+        Region IDs to get ancestry for.
+
+    Returns
+    -------
+    dict[int, list[dict]]
+        Mapping from region ID to list of ancestor structures
+        (from root to leaf).
+    """
+    all_structures = structure_tree.get_structures_by_id(list(region_ids))
+    lookup = {s["id"]: s for s in all_structures}
+
+    result = {}
+    for region_id in region_ids:
+        if region_id not in lookup:
+            continue
+        structure = lookup[region_id]
+        path_ids = structure.get("structure_id_path", [])
+        ancestors = structure_tree.get_structures_by_id(path_ids)
+        result[region_id] = sorted(
+            ancestors, key=lambda x: len(x.get("structure_id_path", []))
+        )
+
+    return result

--- a/src/napari_swc_viewer/widgets/__init__.py
+++ b/src/napari_swc_viewer/widgets/__init__.py
@@ -1,0 +1,14 @@
+"""napari widgets for the SWC viewer."""
+
+from .neuron_viewer import NeuronViewerWidget
+from .reference_layers import add_allen_template, add_region_mesh
+from .region_selector import RegionSelectorWidget
+from .slice_projection import NeuronSliceProjector
+
+__all__ = [
+    "RegionSelectorWidget",
+    "NeuronViewerWidget",
+    "NeuronSliceProjector",
+    "add_allen_template",
+    "add_region_mesh",
+]

--- a/src/napari_swc_viewer/widgets/neuron_viewer.py
+++ b/src/napari_swc_viewer/widgets/neuron_viewer.py
@@ -1,0 +1,641 @@
+"""Main neuron viewer widget combining all components.
+
+This widget provides a unified interface for:
+1. Loading neuron data from Parquet files
+2. Selecting brain regions to filter neurons
+3. Visualizing neurons as points or lines
+4. Displaying Allen CCF reference layers
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from brainglobe_atlasapi import BrainGlobeAtlas
+from napari.utils.notifications import show_info
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSlider,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..db import NeuronDatabase
+from .reference_layers import (
+    add_allen_template,
+    add_brain_outline,
+    add_region_mesh,
+    remove_region_layers,
+)
+from .region_selector import RegionSelectorWidget
+from .slice_projection import NeuronSliceProjector
+
+if TYPE_CHECKING:
+    import napari
+
+logger = logging.getLogger(__name__)
+
+
+class NeuronViewerWidget(QWidget):
+    """Main widget for viewing neurons with brain region filtering.
+
+    This widget integrates:
+    - Parquet file loading and database querying
+    - Hierarchical region selection
+    - Neuron visualization (points or lines)
+    - Allen CCF reference layers
+
+    Parameters
+    ----------
+    napari_viewer : napari.Viewer
+        The napari viewer instance.
+    """
+
+    def __init__(self, napari_viewer: napari.Viewer):
+        super().__init__()
+        self.viewer = napari_viewer
+        self._db: NeuronDatabase | None = None
+        self._atlas: BrainGlobeAtlas | None = None
+        self._current_neuron_layers: list = []
+        self._current_region_layers: list = []
+
+        # Slice projection for 2D viewing
+        self._slice_projector = NeuronSliceProjector(napari_viewer, tolerance=2500.0)
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the widget UI."""
+        layout = QVBoxLayout(self)
+
+        # Tabs for organization
+        tabs = QTabWidget()
+        layout.addWidget(tabs)
+
+        # Data tab
+        data_tab = QWidget()
+        tabs.addTab(data_tab, "Data")
+        self._setup_data_tab(data_tab)
+
+        # Regions tab
+        regions_tab = QWidget()
+        tabs.addTab(regions_tab, "Regions")
+        self._setup_regions_tab(regions_tab)
+
+        # Visualization tab
+        viz_tab = QWidget()
+        tabs.addTab(viz_tab, "Visualization")
+        self._setup_viz_tab(viz_tab)
+
+        # Reference tab
+        ref_tab = QWidget()
+        tabs.addTab(ref_tab, "Reference")
+        self._setup_reference_tab(ref_tab)
+
+    def _setup_data_tab(self, parent: QWidget) -> None:
+        """Set up the data loading tab."""
+        layout = QVBoxLayout(parent)
+
+        # File selection
+        file_group = QGroupBox("Parquet Data")
+        file_layout = QVBoxLayout(file_group)
+
+        file_row = QHBoxLayout()
+        self._file_label = QLabel("No file loaded")
+        self._file_label.setWordWrap(True)
+        file_row.addWidget(self._file_label)
+
+        load_btn = QPushButton("Load...")
+        load_btn.clicked.connect(self._load_parquet)
+        file_row.addWidget(load_btn)
+        file_layout.addLayout(file_row)
+
+        # Stats
+        self._stats_label = QLabel("")
+        file_layout.addWidget(self._stats_label)
+
+        layout.addWidget(file_group)
+
+        # Atlas selection
+        atlas_group = QGroupBox("Atlas")
+        atlas_layout = QHBoxLayout(atlas_group)
+
+        atlas_layout.addWidget(QLabel("Atlas:"))
+        self._atlas_combo = QComboBox()
+        self._atlas_combo.addItems(
+            [
+                "allen_mouse_10um",
+                "allen_mouse_25um",
+                "allen_mouse_50um",
+            ]
+        )
+        self._atlas_combo.setCurrentText("allen_mouse_25um")
+        atlas_layout.addWidget(self._atlas_combo)
+
+        load_atlas_btn = QPushButton("Load Atlas")
+        load_atlas_btn.clicked.connect(self._load_atlas)
+        atlas_layout.addWidget(load_atlas_btn)
+
+        layout.addWidget(atlas_group)
+
+        # Atlas status label
+        self._atlas_status_label = QLabel("Atlas: Not loaded")
+        layout.addWidget(self._atlas_status_label)
+
+        # Selected neurons list
+        neurons_group = QGroupBox("Selected Neurons")
+        neurons_layout = QVBoxLayout(neurons_group)
+
+        self._neuron_list = QListWidget()
+        self._neuron_list.setSelectionMode(QListWidget.ExtendedSelection)
+        neurons_layout.addWidget(self._neuron_list)
+
+        neuron_btn_row = QHBoxLayout()
+        self._render_btn = QPushButton("Render Selected")
+        self._render_btn.clicked.connect(self._render_selected_neurons)
+        neuron_btn_row.addWidget(self._render_btn)
+
+        self._clear_neurons_btn = QPushButton("Clear")
+        self._clear_neurons_btn.clicked.connect(self._clear_neuron_layers)
+        neuron_btn_row.addWidget(self._clear_neurons_btn)
+
+        neurons_layout.addLayout(neuron_btn_row)
+
+        layout.addWidget(neurons_group)
+        layout.addStretch()
+
+    def _setup_regions_tab(self, parent: QWidget) -> None:
+        """Set up the region selection tab."""
+        layout = QVBoxLayout(parent)
+
+        # Region selector widget
+        self._region_selector = RegionSelectorWidget()
+        self._region_selector.selection_changed.connect(self._on_regions_selected)
+        layout.addWidget(self._region_selector)
+
+        # Query button
+        btn_row = QHBoxLayout()
+        self._query_btn = QPushButton("Find Neurons in Selected Regions")
+        self._query_btn.clicked.connect(self._query_neurons_by_region)
+        self._query_btn.setEnabled(False)
+        btn_row.addWidget(self._query_btn)
+        layout.addLayout(btn_row)
+
+    def _setup_viz_tab(self, parent: QWidget) -> None:
+        """Set up the visualization settings tab."""
+        layout = QVBoxLayout(parent)
+
+        # Render mode
+        mode_group = QGroupBox("Render Mode")
+        mode_layout = QVBoxLayout(mode_group)
+
+        self._render_mode_combo = QComboBox()
+        self._render_mode_combo.addItems(["Lines", "Points", "Both"])
+        self._render_mode_combo.setCurrentText("Lines")
+        mode_layout.addWidget(self._render_mode_combo)
+
+        layout.addWidget(mode_group)
+
+        # Point settings
+        point_group = QGroupBox("Point Settings")
+        point_layout = QVBoxLayout(point_group)
+
+        size_row = QHBoxLayout()
+        size_row.addWidget(QLabel("Size:"))
+        self._point_size_spin = QSpinBox()
+        self._point_size_spin.setRange(1, 50)
+        self._point_size_spin.setValue(5)
+        size_row.addWidget(self._point_size_spin)
+        point_layout.addLayout(size_row)
+
+        self._color_by_type_cb = QCheckBox("Color by node type")
+        self._color_by_type_cb.setChecked(True)
+        point_layout.addWidget(self._color_by_type_cb)
+
+        layout.addWidget(point_group)
+
+        # Line settings
+        line_group = QGroupBox("Line Settings")
+        line_layout = QVBoxLayout(line_group)
+
+        width_row = QHBoxLayout()
+        width_row.addWidget(QLabel("Width:"))
+        self._line_width_spin = QSpinBox()
+        self._line_width_spin.setRange(1, 20)
+        self._line_width_spin.setValue(4)
+        self._line_width_spin.valueChanged.connect(self._update_line_width)
+        width_row.addWidget(self._line_width_spin)
+        line_layout.addLayout(width_row)
+
+        layout.addWidget(line_group)
+
+        # 2D Slice Projection settings
+        slice_group = QGroupBox("2D Slice Projection")
+        slice_layout = QVBoxLayout(slice_group)
+
+        self._show_slice_projection_cb = QCheckBox("Show in 2D slices")
+        self._show_slice_projection_cb.setChecked(True)
+        self._show_slice_projection_cb.stateChanged.connect(self._toggle_slice_projection)
+        slice_layout.addWidget(self._show_slice_projection_cb)
+
+        thickness_row = QHBoxLayout()
+        thickness_row.addWidget(QLabel("Slice thickness (μm):"))
+        self._slice_thickness_spin = QSpinBox()
+        self._slice_thickness_spin.setRange(10, 2500)
+        self._slice_thickness_spin.setValue(2500)
+        self._slice_thickness_spin.valueChanged.connect(self._update_slice_thickness)
+        thickness_row.addWidget(self._slice_thickness_spin)
+        slice_layout.addLayout(thickness_row)
+
+        layout.addWidget(slice_group)
+
+        # Opacity
+        opacity_group = QGroupBox("Opacity")
+        opacity_layout = QHBoxLayout(opacity_group)
+
+        self._opacity_slider = QSlider(Qt.Horizontal)
+        self._opacity_slider.setRange(0, 100)
+        self._opacity_slider.setValue(80)
+        opacity_layout.addWidget(self._opacity_slider)
+
+        self._opacity_label = QLabel("80%")
+        self._opacity_slider.valueChanged.connect(
+            lambda v: self._opacity_label.setText(f"{v}%")
+        )
+        opacity_layout.addWidget(self._opacity_label)
+
+        layout.addWidget(opacity_group)
+
+        layout.addStretch()
+
+    def _setup_reference_tab(self, parent: QWidget) -> None:
+        """Set up the reference layers tab."""
+        layout = QVBoxLayout(parent)
+
+        # Template
+        template_group = QGroupBox("Reference Template")
+        template_layout = QVBoxLayout(template_group)
+
+        self._show_template_cb = QCheckBox("Show template")
+        self._show_template_cb.setChecked(False)
+        self._show_template_cb.stateChanged.connect(self._toggle_template)
+        template_layout.addWidget(self._show_template_cb)
+
+        template_opacity_row = QHBoxLayout()
+        template_opacity_row.addWidget(QLabel("Opacity:"))
+        self._template_opacity_slider = QSlider(Qt.Horizontal)
+        self._template_opacity_slider.setRange(0, 100)
+        self._template_opacity_slider.setValue(30)
+        self._template_opacity_slider.valueChanged.connect(self._update_template_opacity)
+        template_opacity_row.addWidget(self._template_opacity_slider)
+        template_layout.addLayout(template_opacity_row)
+
+        layout.addWidget(template_group)
+
+        # Brain outline
+        outline_group = QGroupBox("Brain Outline")
+        outline_layout = QVBoxLayout(outline_group)
+
+        self._show_outline_cb = QCheckBox("Show brain outline")
+        self._show_outline_cb.setChecked(False)
+        self._show_outline_cb.stateChanged.connect(self._toggle_outline)
+        outline_layout.addWidget(self._show_outline_cb)
+
+        layout.addWidget(outline_group)
+
+        # Region meshes
+        mesh_group = QGroupBox("Region Meshes")
+        mesh_layout = QVBoxLayout(mesh_group)
+
+        self._show_region_meshes_cb = QCheckBox("Show selected region meshes")
+        self._show_region_meshes_cb.setChecked(False)
+        self._show_region_meshes_cb.stateChanged.connect(self._toggle_region_meshes)
+        mesh_layout.addWidget(self._show_region_meshes_cb)
+
+        mesh_opacity_row = QHBoxLayout()
+        mesh_opacity_row.addWidget(QLabel("Opacity:"))
+        self._mesh_opacity_slider = QSlider(Qt.Horizontal)
+        self._mesh_opacity_slider.setRange(0, 100)
+        self._mesh_opacity_slider.setValue(30)
+        mesh_opacity_row.addWidget(self._mesh_opacity_slider)
+        mesh_layout.addLayout(mesh_opacity_row)
+
+        layout.addWidget(mesh_group)
+
+        layout.addStretch()
+
+    def _load_parquet(self) -> None:
+        """Open file dialog and load Parquet file."""
+        filepath, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Parquet File",
+            "",
+            "Parquet Files (*.parquet);;All Files (*)",
+        )
+
+        if not filepath:
+            return
+
+        try:
+            self._db = NeuronDatabase(filepath)
+            self._file_label.setText(Path(filepath).name)
+
+            # Update stats
+            stats = self._db.get_statistics()
+            self._stats_label.setText(
+                f"Nodes: {stats['n_nodes']:,} | "
+                f"Files: {stats['n_files']:,} | "
+                f"Subjects: {stats['n_subjects']:,} | "
+                f"Regions: {stats['n_regions']:,}"
+            )
+
+            self._query_btn.setEnabled(True)
+            logger.info(f"Loaded Parquet file: {filepath}")
+
+        except Exception as e:
+            logger.error(f"Failed to load Parquet file: {e}")
+            self._file_label.setText(f"Error: {e}")
+
+    def _load_atlas(self) -> None:
+        """Load the selected BrainGlobe atlas."""
+        atlas_name = self._atlas_combo.currentText()
+
+        self._atlas_status_label.setText(f"Atlas: Loading {atlas_name}...")
+        # Force UI update
+        self._atlas_status_label.repaint()
+
+        try:
+            self._atlas = BrainGlobeAtlas(atlas_name)
+            self._region_selector.set_atlas(self._atlas)
+            self._atlas_status_label.setText(
+                f"Atlas: {atlas_name} ({len(self._atlas.structures)} structures)"
+            )
+            logger.info(f"Loaded atlas: {atlas_name}")
+
+        except Exception as e:
+            logger.error(f"Failed to load atlas: {e}")
+            self._atlas_status_label.setText(f"Atlas: Error - {e}")
+
+    def _on_regions_selected(self, acronyms: list[str]) -> None:
+        """Handle region selection changes."""
+        # Update region meshes if enabled
+        if self._show_region_meshes_cb.isChecked():
+            self._update_region_meshes(acronyms)
+
+    def _query_neurons_by_region(self) -> None:
+        """Query neurons in selected regions."""
+        if self._db is None:
+            return
+
+        acronyms = self._region_selector.get_selected_acronyms(include_children=True)
+        if not acronyms:
+            return
+
+        try:
+            result = self._db.get_neurons_by_region(acronyms)
+
+            # Update neuron list
+            self._neuron_list.clear()
+            for _, row in result.iterrows():
+                item = QListWidgetItem(f"{row['file_id']} ({row['subject']})")
+                item.setData(Qt.UserRole, row["file_id"])
+                self._neuron_list.addItem(item)
+
+            logger.info(f"Found {len(result)} neurons in selected regions")
+
+        except Exception as e:
+            logger.error(f"Query failed: {e}")
+
+    def _render_selected_neurons(self) -> None:
+        """Render the selected neurons from the list."""
+        selected_items = self._neuron_list.selectedItems()
+        if not selected_items or self._db is None:
+            return
+
+        file_ids = [item.data(Qt.UserRole) for item in selected_items]
+
+        # Clear existing neuron layers
+        self._clear_neuron_layers()
+
+        render_mode = self._render_mode_combo.currentText()
+        opacity = self._opacity_slider.value() / 100.0
+
+        # Sample turbo colormap at regular intervals for per-neuron colors
+        n = len(file_ids)
+        cmap = plt.get_cmap("turbo")
+        neuron_colors = [list(cmap(t)) for t in np.linspace(0, 1, n)]
+
+        for file_id, color in zip(file_ids, neuron_colors):
+            if render_mode in ("Lines", "Both"):
+                self._add_neuron_lines(file_id, opacity, color=color)
+            if render_mode in ("Points", "Both"):
+                self._add_neuron_points(file_id, opacity, color=color)
+
+    def _add_neuron_lines(
+        self, file_id: str, opacity: float, color: tuple = (0, 1, 1, 1)
+    ) -> None:
+        """Add a neuron as a shapes layer with lines."""
+        coords, edges = self._db.get_neuron_lines(file_id)
+
+        if len(coords) == 0 or len(edges) == 0:
+            return
+
+        # Create line segments
+        lines = []
+        for edge in edges:
+            lines.append([coords[edge[0]], coords[edge[1]]])
+
+        # Scale to match atlas mesh (coordinates are in microns)
+        scale = None
+        if self._atlas is not None:
+            scale = [1.0 / res for res in self._atlas.resolution]
+
+        layer = self.viewer.add_shapes(
+            lines,
+            shape_type="line",
+            edge_width=self._line_width_spin.value(),
+            edge_color=color,
+            name=f"Lines: {file_id}",
+            opacity=opacity,
+            scale=scale,
+        )
+
+        self._current_neuron_layers.append(layer)
+
+        # Add to slice projector for 2D viewing
+        self._slice_projector.set_scale(scale)
+        self._slice_projector.add_neuron_data(file_id, coords, edges, color=color)
+
+    def _add_neuron_points(
+        self, file_id: str, opacity: float, color: tuple = (1, 0, 1, 1)
+    ) -> None:
+        """Add a neuron as a points layer."""
+        df = self._db.get_neurons_for_rendering([file_id])
+
+        if df.empty:
+            return
+
+        coords = df[["x", "y", "z"]].values
+
+        # Color by node type if enabled
+        if self._color_by_type_cb.isChecked():
+            # Node type colors
+            type_colors = {
+                1: [1, 0, 0, 1],  # Soma - red
+                2: [0, 0, 1, 1],  # Axon - blue
+                3: [0, 1, 0, 1],  # Basal dendrite - green
+                4: [1, 1, 0, 1],  # Apical dendrite - yellow
+            }
+            colors = np.array(
+                [type_colors.get(t, [0.5, 0.5, 0.5, 1]) for t in df["type"].values]
+            )
+        else:
+            colors = color
+
+        # Scale to match atlas mesh (coordinates are in microns)
+        scale = None
+        if self._atlas is not None:
+            scale = [1.0 / res for res in self._atlas.resolution]
+
+        layer = self.viewer.add_points(
+            coords,
+            size=self._point_size_spin.value(),
+            face_color=colors,
+            name=f"Points: {file_id}",
+            opacity=opacity,
+            scale=scale,
+        )
+
+        self._current_neuron_layers.append(layer)
+
+    def _clear_neuron_layers(self) -> None:
+        """Remove all current neuron layers."""
+        for layer in self._current_neuron_layers:
+            try:
+                self.viewer.layers.remove(layer)
+            except ValueError:
+                pass  # Layer already removed
+
+        self._current_neuron_layers.clear()
+
+        # Clear slice projector data
+        self._slice_projector.clear()
+
+    def _toggle_template(self, state: int) -> None:
+        """Toggle the template layer visibility."""
+        if self._atlas is None:
+            self._load_atlas()
+            if self._atlas is None:
+                self._show_template_cb.setChecked(False)
+                return
+
+        layer_name = "Allen Template"
+
+        if state == Qt.Checked:
+            # Check if layer already exists
+            existing = [l for l in self.viewer.layers if l.name == layer_name]
+            if not existing:
+                opacity = self._template_opacity_slider.value() / 100.0
+                add_allen_template(self.viewer, self._atlas, opacity=opacity)
+        else:
+            # Remove template layer
+            for layer in self.viewer.layers:
+                if layer.name == layer_name:
+                    self.viewer.layers.remove(layer)
+                    break
+
+    def _update_template_opacity(self, value: int) -> None:
+        """Update the template layer opacity."""
+        opacity = value / 100.0
+        for layer in self.viewer.layers:
+            if layer.name == "Allen Template":
+                layer.opacity = opacity
+                break
+
+    def _toggle_outline(self, state: int) -> None:
+        """Toggle the brain outline visibility."""
+        if self._atlas is None:
+            self._load_atlas()
+            if self._atlas is None:
+                self._show_outline_cb.setChecked(False)
+                return
+
+        layer_name = "Brain Outline"
+
+        if state == Qt.Checked:
+            existing = [l for l in self.viewer.layers if l.name == layer_name]
+            if not existing:
+                # Switch to 3D mode for mesh viewing
+                if self.viewer.dims.ndisplay == 2:
+                    self.viewer.dims.ndisplay = 3
+                    show_info("Switched to 3D view for mesh display")
+                add_brain_outline(self.viewer, self._atlas)
+        else:
+            for layer in self.viewer.layers:
+                if layer.name == layer_name:
+                    self.viewer.layers.remove(layer)
+                    break
+
+    def _toggle_region_meshes(self, state: int) -> None:
+        """Toggle region mesh visibility."""
+        if state == Qt.Checked:
+            acronyms = self._region_selector.get_selected_acronyms(include_children=False)
+            self._update_region_meshes(acronyms)
+        else:
+            remove_region_layers(self.viewer)
+
+    def _update_region_meshes(self, acronyms: list[str]) -> None:
+        """Update displayed region meshes."""
+        if self._atlas is None:
+            self._load_atlas()
+            if self._atlas is None:
+                return
+
+        # Remove existing region meshes
+        remove_region_layers(self.viewer)
+
+        if not self._show_region_meshes_cb.isChecked():
+            return
+
+        if not acronyms:
+            return
+
+        # Switch to 3D mode for mesh viewing
+        if self.viewer.dims.ndisplay == 2:
+            self.viewer.dims.ndisplay = 3
+            show_info("Switched to 3D view for mesh display")
+
+        # Add new meshes
+        opacity = self._mesh_opacity_slider.value() / 100.0
+        for acronym in acronyms:
+            add_region_mesh(self.viewer, self._atlas, acronym, opacity=opacity)
+
+    def _toggle_slice_projection(self, state: int) -> None:
+        """Toggle the 2D slice projection visibility."""
+        self._slice_projector.enabled = state == Qt.Checked
+
+    def _update_slice_thickness(self, value: int) -> None:
+        """Update the slice projection thickness/tolerance."""
+        self._slice_projector.tolerance = float(value)
+
+    def _update_line_width(self, value: int) -> None:
+        """Update line width for both neuron layers and projection."""
+        for layer in self._current_neuron_layers:
+            if hasattr(layer, "edge_width"):
+                layer.edge_width = value
+        self._slice_projector.edge_width = value

--- a/src/napari_swc_viewer/widgets/reference_layers.py
+++ b/src/napari_swc_viewer/widgets/reference_layers.py
@@ -1,0 +1,333 @@
+"""Allen template and region mesh rendering for napari.
+
+This module provides functions to add Allen CCF reference images and
+brain region meshes to a napari viewer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import napari
+    from brainglobe_atlasapi import BrainGlobeAtlas
+
+logger = logging.getLogger(__name__)
+
+
+def add_allen_template(
+    viewer: napari.Viewer,
+    atlas: BrainGlobeAtlas,
+    name: str = "Allen Template",
+    opacity: float = 0.5,
+    colormap: str = "gray",
+    visible: bool = True,
+) -> napari.layers.Image:
+    """Add the Allen CCF template image to the viewer.
+
+    All layers are in voxel/pixel space (not microns) to match brainrender-napari.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    atlas : BrainGlobeAtlas
+        The atlas to use for the template.
+    name : str, default="Allen Template"
+        Name for the layer.
+    opacity : float, default=0.5
+        Layer opacity.
+    colormap : str, default="gray"
+        Colormap for the image.
+    visible : bool, default=True
+        Whether the layer is visible by default.
+
+    Returns
+    -------
+    napari.layers.Image
+        The created image layer.
+    """
+    # Get reference image (in voxel space)
+    reference = atlas.reference
+
+    layer = viewer.add_image(
+        reference,
+        name=name,
+        opacity=opacity,
+        colormap=colormap,
+        visible=visible,
+        blending="additive",
+    )
+
+    return layer
+
+
+def add_annotation_volume(
+    viewer: napari.Viewer,
+    atlas: BrainGlobeAtlas,
+    name: str = "Allen Annotations",
+    opacity: float = 0.3,
+    visible: bool = False,
+) -> napari.layers.Labels:
+    """Add the Allen CCF annotation volume as a labels layer.
+
+    All layers are in voxel/pixel space (not microns) to match brainrender-napari.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    atlas : BrainGlobeAtlas
+        The atlas to use for annotations.
+    name : str, default="Allen Annotations"
+        Name for the layer.
+    opacity : float, default=0.3
+        Layer opacity.
+    visible : bool, default=False
+        Whether the layer is visible by default.
+
+    Returns
+    -------
+    napari.layers.Labels
+        The created labels layer.
+    """
+    # Annotation volume (in voxel space)
+    annotation = atlas.annotation
+
+    layer = viewer.add_labels(
+        annotation,
+        name=name,
+        opacity=opacity,
+        visible=visible,
+    )
+
+    return layer
+
+
+def add_region_mesh(
+    viewer: napari.Viewer,
+    atlas: BrainGlobeAtlas,
+    acronym: str,
+    opacity: float = 0.4,
+    color: str | tuple | None = None,
+    name: str | None = None,
+    visible: bool = True,
+) -> napari.layers.Surface | None:
+    """Add a brain region mesh to the viewer.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    atlas : BrainGlobeAtlas
+        The atlas to use for the mesh.
+    acronym : str
+        The region acronym (e.g., "VISp").
+    opacity : float, default=0.4
+        Mesh opacity.
+    color : str or tuple, optional
+        Mesh color. If None, uses the atlas's color for the region.
+    name : str, optional
+        Name for the layer. If None, uses "Region: {acronym}".
+    visible : bool, default=True
+        Whether the layer is visible by default.
+
+    Returns
+    -------
+    napari.layers.Surface or None
+        The created surface layer, or None if the region mesh is not available.
+    """
+    # Get structure info - StructuresDict supports direct acronym access via []
+    try:
+        structure = atlas.structures[acronym]
+    except KeyError:
+        logger.warning(f"Region '{acronym}' not found in atlas structures")
+        return None
+
+    # Get mesh using BrainGlobe API
+    try:
+        mesh = atlas.mesh_from_structure(acronym)
+        logger.info(f"Loaded mesh for '{acronym}' with {len(mesh.points)} vertices")
+    except (KeyError, FileNotFoundError) as e:
+        logger.warning(f"Could not load mesh for '{acronym}': {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error loading mesh for '{acronym}': {e}")
+        return None
+
+    # Get vertices and faces (meshio format)
+    # Convert to float32/int32 for better vispy/OpenGL compatibility
+    vertices = mesh.points.astype(np.float32)
+    faces = mesh.cells[0].data.astype(np.int32)
+
+    # Scale mesh from microns to pixel/voxel space to match the reference image
+    scale = [1.0 / res for res in atlas.resolution]
+
+    # Create layer name
+    if name is None:
+        name = f"Region: {acronym}"
+
+    # Determine vertex colors
+    if color is None:
+        rgb = structure.get("rgb_triplet", [128, 128, 128])
+    else:
+        rgb = [int(c * 255) if isinstance(c, float) and c <= 1 else c for c in color]
+
+    # Create vertex colors array (RGB 0-1 for each vertex, float32 for vispy)
+    vertex_colors = np.repeat(
+        [[float(c) / 255 for c in rgb]], len(vertices), axis=0
+    ).astype(np.float32)
+
+    logger.info(f"Creating surface layer '{name}': {len(vertices)} vertices, {len(faces)} faces")
+    layer = viewer.add_surface(
+        (vertices, faces),
+        scale=scale,
+        name=name,
+        opacity=opacity,
+        blending="translucent_no_depth",
+        vertex_colors=vertex_colors,
+        visible=visible,
+    )
+
+    logger.info(f"Added region mesh layer: {layer}")
+    return layer
+
+
+def add_region_meshes(
+    viewer: napari.Viewer,
+    atlas: BrainGlobeAtlas,
+    acronyms: list[str],
+    opacity: float = 0.3,
+    use_atlas_colors: bool = True,
+    visible: bool = True,
+) -> list[napari.layers.Surface]:
+    """Add multiple brain region meshes to the viewer.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    atlas : BrainGlobeAtlas
+        The atlas to use for meshes.
+    acronyms : list[str]
+        List of region acronyms to add.
+    opacity : float, default=0.3
+        Mesh opacity.
+    use_atlas_colors : bool, default=True
+        If True, use the atlas's colors for each region.
+    visible : bool, default=True
+        Whether the layers are visible by default.
+
+    Returns
+    -------
+    list[napari.layers.Surface]
+        List of created surface layers.
+    """
+    layers = []
+    for acronym in acronyms:
+        layer = add_region_mesh(
+            viewer,
+            atlas,
+            acronym,
+            opacity=opacity,
+            color=None if use_atlas_colors else (0.5, 0.5, 0.5),
+            visible=visible,
+        )
+        if layer is not None:
+            layers.append(layer)
+
+    return layers
+
+
+def add_brain_outline(
+    viewer: napari.Viewer,
+    atlas: BrainGlobeAtlas,
+    opacity: float = 0.2,
+    name: str = "Brain Outline",
+    visible: bool = True,
+) -> napari.layers.Surface | None:
+    """Add the whole brain outline mesh to the viewer.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    atlas : BrainGlobeAtlas
+        The atlas to use.
+    opacity : float, default=0.2
+        Mesh opacity.
+    name : str, default="Brain Outline"
+        Name for the layer.
+    visible : bool, default=True
+        Whether the layer is visible by default.
+
+    Returns
+    -------
+    napari.layers.Surface or None
+        The created surface layer, or None if not available.
+    """
+    # Get the root mesh using BrainGlobe API
+    try:
+        mesh = atlas.mesh_from_structure("root")
+        logger.info(f"Loaded root mesh with {len(mesh.points)} vertices")
+    except (KeyError, FileNotFoundError) as e:
+        logger.warning(f"Could not load root mesh: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error loading root mesh: {e}")
+        return None
+
+    # Get vertices and faces (meshio format)
+    # Convert to float32/int32 for better vispy/OpenGL compatibility
+    vertices = mesh.points.astype(np.float32)
+    faces = mesh.cells[0].data.astype(np.int32)
+
+    # Scale mesh from microns to pixel/voxel space to match the reference image
+    scale = [1.0 / res for res in atlas.resolution]
+
+    # Gray color for outline (float32 for vispy)
+    vertex_colors = np.repeat([[0.5, 0.5, 0.5]], len(vertices), axis=0).astype(np.float32)
+
+    logger.info(f"Creating brain outline surface: {len(vertices)} vertices, {len(faces)} faces")
+
+    layer = viewer.add_surface(
+        (vertices, faces),
+        scale=scale,
+        name=name,
+        opacity=opacity,
+        blending="translucent_no_depth",
+        vertex_colors=vertex_colors,
+        visible=visible,
+    )
+
+    logger.info(f"Added brain outline layer: {layer}")
+    return layer
+
+
+def remove_region_layers(
+    viewer: napari.Viewer,
+    prefix: str = "Region:",
+) -> int:
+    """Remove all region mesh layers from the viewer.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The napari viewer instance.
+    prefix : str, default="Region:"
+        Prefix to match for layer names.
+
+    Returns
+    -------
+    int
+        Number of layers removed.
+    """
+    to_remove = [layer for layer in viewer.layers if layer.name.startswith(prefix)]
+
+    for layer in to_remove:
+        viewer.layers.remove(layer)
+
+    return len(to_remove)

--- a/src/napari_swc_viewer/widgets/region_selector.py
+++ b/src/napari_swc_viewer/widgets/region_selector.py
@@ -1,0 +1,389 @@
+"""Region selector widget with hierarchical Allen CCF structure tree."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+if TYPE_CHECKING:
+    from brainglobe_atlasapi import BrainGlobeAtlas
+
+
+class RegionSelectorWidget(QWidget):
+    """Widget for hierarchical brain region selection.
+
+    This widget displays the Allen CCF brain region hierarchy as a tree
+    and allows users to select regions for filtering neurons.
+
+    Signals
+    -------
+    selection_changed
+        Emitted when the selection changes, with list of selected region acronyms.
+    """
+
+    selection_changed = Signal(list)  # Emits list of selected acronyms
+
+    def __init__(
+        self,
+        atlas: BrainGlobeAtlas | None = None,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent)
+        self._atlas = atlas
+        self._structure_map: dict[int, dict] = {}
+        self._items_by_id: dict[int, QTreeWidgetItem] = {}
+
+        self._setup_ui()
+
+        if atlas is not None:
+            self.set_atlas(atlas)
+
+    def _setup_ui(self) -> None:
+        """Set up the widget UI."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Search bar
+        search_layout = QHBoxLayout()
+        self._search_input = QLineEdit()
+        self._search_input.setPlaceholderText("Search regions...")
+        self._search_input.textChanged.connect(self._on_search_changed)
+        search_layout.addWidget(self._search_input)
+
+        self._clear_search_btn = QPushButton("Clear")
+        self._clear_search_btn.clicked.connect(self._clear_search)
+        search_layout.addWidget(self._clear_search_btn)
+        layout.addLayout(search_layout)
+
+        # Tree widget
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(["Region", "Acronym"])
+        self._tree.setColumnWidth(0, 250)
+        self._tree.itemChanged.connect(self._on_item_changed)
+        layout.addWidget(self._tree)
+
+        # Selection info
+        info_layout = QHBoxLayout()
+        self._selection_label = QLabel("Selected: 0 regions")
+        info_layout.addWidget(self._selection_label)
+
+        self._clear_btn = QPushButton("Clear Selection")
+        self._clear_btn.clicked.connect(self._clear_selection)
+        info_layout.addWidget(self._clear_btn)
+        layout.addLayout(info_layout)
+
+        # Include children option
+        self._include_children_cb = QCheckBox("Include child regions")
+        self._include_children_cb.setChecked(True)
+        self._include_children_cb.stateChanged.connect(self._emit_selection_changed)
+        layout.addWidget(self._include_children_cb)
+
+    def set_atlas(self, atlas: BrainGlobeAtlas) -> None:
+        """Set the atlas and populate the tree.
+
+        Parameters
+        ----------
+        atlas : BrainGlobeAtlas
+            The atlas to use for region hierarchy.
+        """
+        self._atlas = atlas
+        self._populate_tree()
+
+    def _populate_tree(self) -> None:
+        """Populate the tree with the atlas structure hierarchy."""
+        if self._atlas is None:
+            return
+
+        self._tree.blockSignals(True)
+        self._tree.clear()
+        self._items_by_id.clear()
+        self._structure_map.clear()
+
+        # Build structure lookup
+        for struct_id, struct in self._atlas.structures.items():
+            if isinstance(struct_id, int):
+                self._structure_map[struct_id] = struct
+
+        # Find root structures (those without a parent in our map)
+        root_ids = set()
+        for struct_id, struct in self._structure_map.items():
+            parent_id = struct.get("parent_structure_id")
+            if parent_id is None or parent_id not in self._structure_map:
+                root_ids.add(struct_id)
+
+        # Build tree recursively from roots
+        for root_id in sorted(root_ids):
+            self._add_structure_to_tree(root_id, None)
+
+        self._tree.blockSignals(False)
+
+    def _add_structure_to_tree(
+        self,
+        struct_id: int,
+        parent_item: QTreeWidgetItem | None,
+    ) -> QTreeWidgetItem | None:
+        """Add a structure and its children to the tree.
+
+        Parameters
+        ----------
+        struct_id : int
+            The structure ID to add.
+        parent_item : QTreeWidgetItem or None
+            The parent tree item, or None for root items.
+
+        Returns
+        -------
+        QTreeWidgetItem or None
+            The created tree item.
+        """
+        struct = self._structure_map.get(struct_id)
+        if struct is None:
+            return None
+
+        name = struct.get("name", f"Region {struct_id}")
+        acronym = struct.get("acronym", "")
+
+        if parent_item is None:
+            item = QTreeWidgetItem(self._tree, [name, acronym])
+        else:
+            item = QTreeWidgetItem(parent_item, [name, acronym])
+
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setCheckState(0, Qt.Unchecked)
+        item.setData(0, Qt.UserRole, struct_id)
+
+        self._items_by_id[struct_id] = item
+
+        # Add children
+        children_ids = self._get_child_structure_ids(struct_id)
+        for child_id in sorted(children_ids):
+            self._add_structure_to_tree(child_id, item)
+
+        return item
+
+    def _get_child_structure_ids(self, parent_id: int) -> list[int]:
+        """Get direct child structure IDs for a parent.
+
+        Parameters
+        ----------
+        parent_id : int
+            The parent structure ID.
+
+        Returns
+        -------
+        list[int]
+            List of child structure IDs.
+        """
+        children = []
+        for struct_id, struct in self._structure_map.items():
+            if struct.get("parent_structure_id") == parent_id:
+                children.append(struct_id)
+        return children
+
+    def _on_item_changed(self, item: QTreeWidgetItem, column: int) -> None:
+        """Handle item check state changes."""
+        if column != 0:
+            return
+
+        # Update selection count and emit signal
+        self._update_selection_label()
+        self._emit_selection_changed()
+
+    def _on_search_changed(self, text: str) -> None:
+        """Filter tree items based on search text."""
+        text = text.lower().strip()
+
+        def set_item_visibility(item: QTreeWidgetItem) -> bool:
+            """Recursively set item visibility. Returns True if visible."""
+            # Check children first
+            child_visible = False
+            for i in range(item.childCount()):
+                if set_item_visibility(item.child(i)):
+                    child_visible = True
+
+            # Check this item's text
+            name = item.text(0).lower()
+            acronym = item.text(1).lower()
+            matches = not text or text in name or text in acronym
+
+            # Item is visible if it matches or has visible children
+            visible = matches or child_visible
+            item.setHidden(not visible)
+
+            # Expand items that match
+            if matches and text:
+                item.setExpanded(True)
+
+            return visible
+
+        for i in range(self._tree.topLevelItemCount()):
+            set_item_visibility(self._tree.topLevelItem(i))
+
+    def _clear_search(self) -> None:
+        """Clear the search input and show all items."""
+        self._search_input.clear()
+        self._show_all_items()
+
+    def _show_all_items(self) -> None:
+        """Show all items in the tree."""
+
+        def show_item(item: QTreeWidgetItem) -> None:
+            item.setHidden(False)
+            for i in range(item.childCount()):
+                show_item(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            show_item(self._tree.topLevelItem(i))
+
+    def _clear_selection(self) -> None:
+        """Clear all selections."""
+        self._tree.blockSignals(True)
+
+        def uncheck_item(item: QTreeWidgetItem) -> None:
+            item.setCheckState(0, Qt.Unchecked)
+            for i in range(item.childCount()):
+                uncheck_item(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            uncheck_item(self._tree.topLevelItem(i))
+
+        self._tree.blockSignals(False)
+        self._update_selection_label()
+        self._emit_selection_changed()
+
+    def _update_selection_label(self) -> None:
+        """Update the selection count label."""
+        selected = self.get_selected_acronyms(include_children=False)
+        self._selection_label.setText(f"Selected: {len(selected)} regions")
+
+    def _emit_selection_changed(self) -> None:
+        """Emit the selection_changed signal with current selection."""
+        acronyms = self.get_selected_acronyms(
+            include_children=self._include_children_cb.isChecked()
+        )
+        self.selection_changed.emit(acronyms)
+
+    def get_selected_acronyms(self, include_children: bool = True) -> list[str]:
+        """Get the list of selected region acronyms.
+
+        Parameters
+        ----------
+        include_children : bool, default=True
+            If True, include child region acronyms for selected parent regions.
+
+        Returns
+        -------
+        list[str]
+            List of selected region acronyms.
+        """
+        selected_ids = set()
+
+        def collect_checked(item: QTreeWidgetItem) -> None:
+            if item.checkState(0) == Qt.Checked:
+                struct_id = item.data(0, Qt.UserRole)
+                if struct_id is not None:
+                    selected_ids.add(struct_id)
+
+                    if include_children:
+                        # Add all descendants
+                        self._collect_descendant_ids(struct_id, selected_ids)
+            else:
+                # Check children even if parent is unchecked
+                for i in range(item.childCount()):
+                    collect_checked(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            collect_checked(self._tree.topLevelItem(i))
+
+        # Convert IDs to acronyms
+        acronyms = []
+        for struct_id in selected_ids:
+            struct = self._structure_map.get(struct_id)
+            if struct and struct.get("acronym"):
+                acronyms.append(struct["acronym"])
+
+        return sorted(set(acronyms))
+
+    def _collect_descendant_ids(self, struct_id: int, result: set[int]) -> None:
+        """Recursively collect all descendant structure IDs.
+
+        Parameters
+        ----------
+        struct_id : int
+            The structure ID to get descendants for.
+        result : set[int]
+            Set to add descendant IDs to.
+        """
+        children = self._get_child_structure_ids(struct_id)
+        for child_id in children:
+            result.add(child_id)
+            self._collect_descendant_ids(child_id, result)
+
+    def get_selected_ids(self, include_children: bool = True) -> list[int]:
+        """Get the list of selected region IDs.
+
+        Parameters
+        ----------
+        include_children : bool, default=True
+            If True, include child region IDs for selected parent regions.
+
+        Returns
+        -------
+        list[int]
+            List of selected region IDs.
+        """
+        selected_ids = set()
+
+        def collect_checked(item: QTreeWidgetItem) -> None:
+            if item.checkState(0) == Qt.Checked:
+                struct_id = item.data(0, Qt.UserRole)
+                if struct_id is not None:
+                    selected_ids.add(struct_id)
+
+                    if include_children:
+                        self._collect_descendant_ids(struct_id, selected_ids)
+            else:
+                for i in range(item.childCount()):
+                    collect_checked(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            collect_checked(self._tree.topLevelItem(i))
+
+        return sorted(selected_ids)
+
+    def select_regions(self, acronyms: list[str]) -> None:
+        """Programmatically select regions by acronym.
+
+        Parameters
+        ----------
+        acronyms : list[str]
+            List of region acronyms to select.
+        """
+        acronym_set = set(acronyms)
+        self._tree.blockSignals(True)
+
+        def check_matching(item: QTreeWidgetItem) -> None:
+            acronym = item.text(1)
+            if acronym in acronym_set:
+                item.setCheckState(0, Qt.Checked)
+            for i in range(item.childCount()):
+                check_matching(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            check_matching(self._tree.topLevelItem(i))
+
+        self._tree.blockSignals(False)
+        self._update_selection_label()
+        self._emit_selection_changed()


### PR DESCRIPTION
## Summary

- Restore widget, database, reader, and supporting modules from git history
- Automatically assign distinct colors to each neuron by sampling the **turbo** colormap at `N` evenly spaced intervals (`np.linspace(0, 1, N)`)
- Per-neuron colors apply to 3D line rendering, 2D slice projections, and points mode (when "color by type" is unchecked)
- Register widget and reader in napari manifest so the plugin appears in the menu
- Add missing dependencies: `matplotlib`, `duckdb`, `pyarrow`, `pandas`, `qtpy`

### 2D Slice Projection improvements

- Fix coordinate conversion: use `dims.point` instead of `dims.current_step` for correct world-to-data mapping
- Flatten projected lines onto the slice plane so they render as full 2D segments (not invisible 3D piercings)
- Support all slice orientations via `dims.not_displayed` axis detection
- Connect line width spinner to both neuron layers and projection layer
- Configurable slab thickness up to 2500μm
- Vectorize projection with precomputed numpy arrays (~30K edges filtered per update with no Python loops)

Closes #6

## Test plan

- [x] Each rendered axon has a unique color from the turbo colormap
- [x] Colors are evenly distributed across the colormap range
- [x] Works correctly for any number of axons (1 to many)
- [x] 2D slice projection shows clear lines as you scroll through slices
- [x] Projection works in all three slice orientations
- [x] Line width spinner controls both neuron layers and projection layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)