### PR TITLE
Add standardized point Parquet import workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,9 @@ example_data_aligned/
 
 # Parquet data files
 *.parquet
+
+# CSV data files
+*.csv
+
+# JSON conversion files
+*.json

--- a/MANUAL.MD
+++ b/MANUAL.MD
@@ -56,6 +56,14 @@ Recommended Parquet schema columns:
 - `region_id`, `region_name`, `region_acronym`
 - `subject`, `neuron_id`
 
+### Standard point Parquet files
+
+- Produced from raw CSVs using `scripts/convert_point_csv.py`
+- Imported through the widget Data tab with `Import Point Parquet...`
+- Required columns: `label`, `x`, `y`, `z`
+- Optional columns: `region_name`, `acronym`, `id`, `hemisphere`
+- Any additional columns are preserved and added as napari point properties
+
 ## Typical workflow
 
 ### 1. Open Neuron Viewer
@@ -82,6 +90,13 @@ In **Atlas**:
 
 1. Choose atlas (`allen_mouse_10um`, `25um`, or `50um`)
 2. Click `Load Atlas`
+
+In **Point Parquet Import**:
+
+1. Click `Import Point Parquet...`
+2. Choose a standardized point `.parquet` file
+3. The app adds one `Points` layer per unique `label`
+4. If optional atlas metadata columns are present, the app checks them against the selected atlas and warns on mismatches
 
 Notes:
 
@@ -197,6 +212,36 @@ Data tab, **Convert SWC to Parquet**:
 
 Conversion runs in a background worker with progress updates.
 
+## CSV to standard point Parquet conversion
+
+This repo also provides a converter for atlas-registered point CSV files:
+
+```bash
+python scripts/convert_point_csv.py raw_points.csv mapping.json points.parquet
+```
+
+Mapping JSON format:
+
+```json
+{
+  "label": "marker",
+  "x": "atlas_x",
+  "y": "atlas_y",
+  "z": "atlas_z",
+  "region_name": "region_name",
+  "acronym": "acronym",
+  "id": "id",
+  "hemisphere": "hemisphere"
+}
+```
+
+Notes:
+
+- Mapping keys are the standard target column names
+- `label`, `x`, `y`, and `z` mappings are required
+- The converter preserves any unmapped source columns in the output Parquet
+- The converter validates numeric `x`, `y`, `z`, and `id` values before writing output
+
 ## Command-line hemisphere utility
 
 This repo also provides a script for hemisphere detection and coordinate flipping:
@@ -232,6 +277,13 @@ Useful flags:
 - Ensure both a Parquet file and atlas are loaded
 - Use a region containing enough neurons/somas
 - For DBSCAN, increase `eps` or reduce `min_samples` if clusters are not found
+
+### “Point Parquet import failed”
+
+- Confirm the file contains standardized `label`, `x`, `y`, `z` columns
+- Re-run `scripts/convert_point_csv.py` if you started from a raw CSV
+- Load the target atlas before importing point Parquet
+- If the app warns about metadata mismatches, the point layers are still imported; review optional `region_name`, `acronym`, `id`, and `hemisphere` values
 
 ### Slow 2D slicing
 

--- a/MANUAL.MD
+++ b/MANUAL.MD
@@ -62,7 +62,7 @@ Recommended Parquet schema columns:
 - Imported through the widget Data tab with `Import Point Parquet...`
 - Required columns: `label`, `x`, `y`, `z`
 - Optional columns: `region_name`, `acronym`, `id`, `hemisphere`
-- Any additional columns are preserved and added as napari point properties
+- Any additional columns are preserved in the standardized Parquet
 
 ## Typical workflow
 
@@ -95,7 +95,7 @@ In **Point Parquet Import**:
 
 1. Click `Import Point Parquet...`
 2. Choose a standardized point `.parquet` file
-3. The app adds one `Points` layer per unique `label`
+3. The app adds one heatmap image layer per unique `label`
 4. If optional atlas metadata columns are present, the app checks them against the selected atlas and warns on mismatches
 
 Notes:

--- a/MANUAL.MD
+++ b/MANUAL.MD
@@ -95,7 +95,7 @@ In **Point Parquet Import**:
 
 1. Click `Import Point Parquet...`
 2. Choose a standardized point `.parquet` file
-3. The app adds one heatmap image layer per unique `label`
+3. The app adds one heatmap image layer per unique `label`, using a different color for each layer
 4. If optional atlas metadata columns are present, the app checks them against the selected atlas and warns on mismatches
 
 Notes:
@@ -283,7 +283,7 @@ Useful flags:
 - Confirm the file contains standardized `label`, `x`, `y`, `z` columns
 - Re-run `scripts/convert_point_csv.py` if you started from a raw CSV
 - Load the target atlas before importing point Parquet
-- If the app warns about metadata mismatches, the point layers are still imported; review optional `region_name`, `acronym`, `id`, and `hemisphere` values
+- If the app warns about metadata mismatches, the heatmap layers are still imported; review optional `region_name`, `acronym`, `id`, and `hemisphere` values
 
 ### Slow 2D slicing
 

--- a/MANUAL.MD
+++ b/MANUAL.MD
@@ -106,14 +106,29 @@ Notes:
 
 ### 3. Select regions (Regions tab)
 
-1. Use search to find structures
-2. Check regions in the tree
-3. Optionally enable/disable `Include child regions`
-4. Click `Find Neurons in Selected Regions`
+1. Choose `Query source`
+2. For `Atlas Regions`, use search to find structures, check regions in the tree, and optionally enable/disable `Include child regions`
+3. For `Mask Layer`, check one or more generated mask layers and select either `Any node in mask` or `Soma in mask`
+4. Click the query button for the active source
 
 This fills the **Selected Neurons** table in the Data tab.
 
-### 4. Manage selected neurons (Data tab table)
+### 4. Build masks from heatmaps (Tools tab)
+
+1. Select one or more eligible heatmap layers
+2. Choose `Separate masks` or `Merged mask`
+3. Set Gaussian sigma in atlas voxels
+4. Choose `Otsu` or `Manual` thresholding
+5. Click `Create Mask Layer`
+
+Notes:
+
+- Only app-created heatmaps on the native atlas voxel grid are eligible
+- Depth-binned analysis heatmaps are excluded from mask creation in this version
+- Generated masks are added as binary `Labels` layers and can be used from the `Regions` tab
+- Gaussian sigma is in atlas voxels; for example, on `allen_mouse_25um`, `1.0` means `1 voxel = 25 µm`
+
+### 5. Manage selected neurons (Data tab table)
 
 In the table you can:
 
@@ -129,7 +144,7 @@ Buttons:
 - `Clear All`: remove all neuron layers.
 - Centering mode (`Same` | `Auto`): `Same` keeps the current depth slice after add/remove. `Auto` auto-centers once on first add/remove in the widget session.
 
-### 5. Configure rendering (Visualization tab)
+### 6. Configure rendering (Visualization tab)
 
 Controls:
 
@@ -145,7 +160,7 @@ Rendering behavior:
 - In 2D mode, line/point layers are auto-hidden to keep navigation responsive
 - Optional `Neuron Slice Projection` (vectors layer) shows line segments near current slice
 
-### 6. Add reference context (Reference tab)
+### 7. Add reference context (Reference tab)
 
 Available layers:
 
@@ -159,7 +174,7 @@ Notes:
 - Mesh display auto-switches napari to 3D mode
 - Segmentation is intended for 2D context overlays
 
-### 7. Run analysis (Analysis tab)
+### 8. Run analysis (Analysis tab)
 
 ### Clustering
 
@@ -284,6 +299,18 @@ Useful flags:
 - Re-run `scripts/convert_point_csv.py` if you started from a raw CSV
 - Load the target atlas before importing point Parquet
 - If the app warns about metadata mismatches, the heatmap layers are still imported; review optional `region_name`, `acronym`, `id`, and `hemisphere` values
+
+### “No eligible heatmaps” in Tools
+
+- Only app-created heatmap image layers are listed
+- The heatmap must match the currently loaded atlas
+- Depth-binned analysis heatmaps are excluded because they are not on the native atlas voxel grid
+
+### “No neurons found” for a mask query
+
+- Confirm the selected mask layer contains nonzero voxels
+- Try `Any node in mask` before `Soma in mask`
+- Check that the mask was created from heatmaps for the same atlas resolution as the loaded dataset
 
 ### Slow 2D slicing
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ In the plugin Data tab, use `Import Point Parquet...` to load the standardized
 Parquet. The selected atlas must already be loaded. If optional atlas metadata
 columns are present, the app validates them against the selected atlas,
 warns on mismatches, and imports one heatmap image layer per unique `label`.
+Each heatmap layer is assigned a distinct color so labels are easier to
+differentiate in the viewer.
 
 ## Hemisphere Detection and Coordinate Flipping
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,42 @@ To run tests with coverage:
 pixi run test-cov
 ```
 
+## Standard Point Parquet Workflow
+
+This repo now supports atlas-registered point datasets via a standardized
+point Parquet schema:
+
+- Required columns: `label`, `x`, `y`, `z`
+- Optional columns: `region_name`, `acronym`, `id`, `hemisphere`
+- Additional source columns are preserved and imported as point properties
+
+To convert a raw CSV into standardized point Parquet, provide a JSON
+mapping from standard target names to source CSV headers:
+
+```json
+{
+  "label": "marker",
+  "x": "atlas_x",
+  "y": "atlas_y",
+  "z": "atlas_z",
+  "region_name": "region_name",
+  "acronym": "acronym",
+  "id": "id",
+  "hemisphere": "hemisphere"
+}
+```
+
+Run the converter from the repository root:
+
+```bash
+pixi run python scripts/convert_point_csv.py raw_points.csv mapping.json points.parquet
+```
+
+In the plugin Data tab, use `Import Point Parquet...` to load the standardized
+Parquet. The selected atlas must already be loaded. If optional atlas metadata
+columns are present, the app validates them against the selected atlas,
+warns on mismatches, and still imports one `Points` layer per unique `label`.
+
 ## Hemisphere Detection and Coordinate Flipping
 
 This plugin includes functionality to detect which brain hemisphere an SWC morphology is located in and to flip coordinates from one hemisphere to the other. This is useful for standardizing neuron reconstructions to a common hemisphere for analysis.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ warns on mismatches, and imports one heatmap image layer per unique `label`.
 Each heatmap layer is assigned a distinct color so labels are easier to
 differentiate in the viewer.
 
+In the `Tools` tab, eligible native-grid heatmaps can be converted into 3D
+binary mask `Labels` layers using Gaussian smoothing plus either Otsu or manual
+thresholding. The `Regions` tab can then query neurons either by Allen regions
+or by one or more of these generated mask layers, using either any-node or soma-only
+membership.
+
 ## Hemisphere Detection and Coordinate Flipping
 
 This plugin includes functionality to detect which brain hemisphere an SWC morphology is located in and to flip coordinates from one hemisphere to the other. This is useful for standardizing neuron reconstructions to a common hemisphere for analysis.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ point Parquet schema:
 
 - Required columns: `label`, `x`, `y`, `z`
 - Optional columns: `region_name`, `acronym`, `id`, `hemisphere`
-- Additional source columns are preserved and imported as point properties
+- Additional source columns are preserved in the standardized Parquet
 
 To convert a raw CSV into standardized point Parquet, provide a JSON
 mapping from standard target names to source CSV headers:
@@ -79,7 +79,7 @@ pixi run python scripts/convert_point_csv.py raw_points.csv mapping.json points.
 In the plugin Data tab, use `Import Point Parquet...` to load the standardized
 Parquet. The selected atlas must already be loaded. If optional atlas metadata
 columns are present, the app validates them against the selected atlas,
-warns on mismatches, and still imports one `Points` layer per unique `label`.
+warns on mismatches, and imports one heatmap image layer per unique `label`.
 
 ## Hemisphere Detection and Coordinate Flipping
 

--- a/scripts/convert_point_csv.py
+++ b/scripts/convert_point_csv.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Normalize atlas-registered point CSVs into standardized Parquet."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from napari_swc_viewer.point_import import (
+    OPTIONAL_POINT_COLUMNS,
+    REQUIRED_POINT_COLUMNS,
+    convert_point_csv_to_parquet,
+)
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a raw atlas-registered point CSV plus a JSON column mapping "
+            "into standardized point Parquet."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Required standardized columns:
+  {", ".join(REQUIRED_POINT_COLUMNS)}
+
+Optional standardized columns:
+  {", ".join(OPTIONAL_POINT_COLUMNS)}
+
+Mapping JSON format:
+  {{"label":"marker","x":"atlas_x","y":"atlas_y","z":"atlas_z"}}
+
+Example:
+  %(prog)s raw_points.csv mapping.json points_standardized.parquet
+""",
+    )
+    parser.add_argument("input_csv", type=Path, help="Raw input CSV file")
+    parser.add_argument(
+        "mapping_json",
+        type=Path,
+        help="JSON file mapping standard column names to source CSV headers",
+    )
+    parser.add_argument(
+        "output_parquet",
+        type=Path,
+        help="Output standardized Parquet path",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None) -> int:
+    """Run the CSV-to-Parquet conversion."""
+
+    parsed = parse_args(args)
+    try:
+        standardized = convert_point_csv_to_parquet(
+            parsed.input_csv,
+            parsed.mapping_json,
+            parsed.output_parquet,
+        )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Wrote {len(standardized):,} standardized point rows to "
+        f"{parsed.output_parquet}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/napari_swc_viewer/analysis/__init__.py
+++ b/src/napari_swc_viewer/analysis/__init__.py
@@ -18,15 +18,23 @@ from .correlation import (
 )
 from .heatmap import build_node_counts_volume
 from .mask import (
+    build_binary_mask_from_heatmap,
     dilate_mask_to_volume_increase,
     get_expanded_region_voxel_ids,
     get_region_mask,
+    merge_heatmap_volumes,
+    otsu_threshold_positive,
+    smooth_heatmap_volume,
 )
 
 __all__ = [
     "get_region_mask",
     "dilate_mask_to_volume_increase",
     "get_expanded_region_voxel_ids",
+    "smooth_heatmap_volume",
+    "merge_heatmap_volumes",
+    "otsu_threshold_positive",
+    "build_binary_mask_from_heatmap",
     "compute_pearson_correlation_matrix",
     "correlation_long_to_matrix",
     "build_node_counts_volume",

--- a/src/napari_swc_viewer/analysis/mask.py
+++ b/src/napari_swc_viewer/analysis/mask.py
@@ -11,13 +11,105 @@ import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.ndimage import distance_transform_edt
+from scipy.ndimage import distance_transform_edt, gaussian_filter
 
 if TYPE_CHECKING:
     from brainglobe_atlasapi import BrainGlobeAtlas
     from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
+
+
+def smooth_heatmap_volume(
+    volume: NDArray[np.floating] | np.ndarray,
+    sigma: float = 1.0,
+) -> NDArray[np.float32]:
+    """Smooth a 3D heatmap volume with a Gaussian kernel."""
+    arr = np.asarray(volume, dtype=np.float32)
+    if arr.ndim != 3:
+        raise ValueError(f"Expected a 3D volume, got shape {arr.shape}")
+    if sigma <= 0:
+        return arr.copy()
+    return gaussian_filter(arr, sigma=float(sigma), mode="nearest").astype(np.float32)
+
+
+def merge_heatmap_volumes(
+    volumes: list[NDArray[np.floating] | np.ndarray],
+) -> NDArray[np.float32]:
+    """Sum multiple heatmap volumes voxelwise."""
+    if not volumes:
+        raise ValueError("At least one heatmap volume is required.")
+
+    arrays = [np.asarray(volume, dtype=np.float32) for volume in volumes]
+    first_shape = arrays[0].shape
+    if any(arr.ndim != 3 for arr in arrays):
+        raise ValueError("All heatmap volumes must be 3D.")
+    if any(arr.shape != first_shape for arr in arrays[1:]):
+        raise ValueError("All heatmap volumes must have the same shape.")
+    return np.sum(arrays, axis=0, dtype=np.float32)
+
+
+def otsu_threshold_positive(
+    volume: NDArray[np.floating] | np.ndarray,
+    bins: int = 256,
+) -> float:
+    """Compute an Otsu threshold using only positive voxels."""
+    positive = np.asarray(volume, dtype=np.float32)
+    positive = positive[np.isfinite(positive) & (positive > 0)]
+    if positive.size == 0:
+        return 0.0
+
+    min_value = float(positive.min())
+    max_value = float(positive.max())
+    if max_value <= min_value:
+        return min_value
+
+    hist, bin_edges = np.histogram(positive, bins=min(int(bins), int(positive.size)))
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) * 0.5
+    weight1 = np.cumsum(hist)
+    weight2 = hist.sum() - weight1
+    weighted = hist * bin_centers
+    mean1 = np.divide(
+        np.cumsum(weighted),
+        weight1,
+        out=np.zeros_like(bin_centers),
+        where=weight1 > 0,
+    )
+    mean2 = np.divide(
+        np.cumsum(weighted[::-1])[::-1],
+        weight2,
+        out=np.zeros_like(bin_centers),
+        where=weight2 > 0,
+    )
+    between = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
+    if between.size == 0:
+        return min_value
+    return float(bin_centers[int(np.argmax(between))])
+
+
+def build_binary_mask_from_heatmap(
+    volume: NDArray[np.floating] | np.ndarray,
+    sigma: float = 1.0,
+    threshold_mode: str = "otsu",
+    manual_threshold: float | None = None,
+) -> tuple[NDArray[np.uint8], float, NDArray[np.float32]]:
+    """Create a binary mask from a heatmap via smoothing and thresholding."""
+    smoothed = smooth_heatmap_volume(volume, sigma=sigma)
+    mode = str(threshold_mode).strip().lower()
+    if mode == "manual":
+        if manual_threshold is None:
+            raise ValueError("Manual threshold mode requires a threshold value.")
+        threshold = float(manual_threshold)
+    elif mode == "otsu":
+        threshold = otsu_threshold_positive(smoothed)
+    else:
+        raise ValueError(f"Unknown threshold mode: {threshold_mode}")
+
+    if mode == "otsu" and not np.any(smoothed > 0):
+        mask = np.zeros(smoothed.shape, dtype=np.uint8)
+    else:
+        mask = (smoothed >= threshold).astype(np.uint8, copy=False)
+    return mask, threshold, smoothed
 
 
 def get_region_mask(atlas: BrainGlobeAtlas, acronym: str) -> NDArray[np.bool_]:

--- a/src/napari_swc_viewer/atlas_utils.py
+++ b/src/napari_swc_viewer/atlas_utils.py
@@ -1,0 +1,44 @@
+"""Shared atlas coordinate conversion helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def atlas_resolution_array(atlas_or_resolution: Any) -> np.ndarray:
+    """Return atlas resolution as a float XYZ array."""
+    resolution = getattr(atlas_or_resolution, "resolution", atlas_or_resolution)
+    return np.asarray(resolution, dtype=float)
+
+
+def world_coords_xyz_to_atlas_voxels(
+    coords_xyz: np.ndarray,
+    atlas_or_resolution: Any,
+) -> np.ndarray:
+    """Convert world-space XYZ micron coordinates to atlas ZYX voxel indices."""
+    resolution = atlas_resolution_array(atlas_or_resolution)
+    coords = np.asarray(coords_xyz, dtype=float)
+    if coords.ndim == 1:
+        coords = coords.reshape(1, 3)
+    lookup_coords = coords[:, [2, 1, 0]]
+    return np.round(lookup_coords / resolution).astype(int)
+
+
+def mask_to_world_xyz_bounds(
+    mask_volume: np.ndarray,
+    atlas_or_resolution: Any,
+    padding_voxels: float = 0.5,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Return conservative XYZ world bounds for a nonzero atlas mask."""
+    nonzero = np.argwhere(np.asarray(mask_volume) > 0)
+    if len(nonzero) == 0:
+        return None
+
+    resolution = atlas_resolution_array(atlas_or_resolution)
+    lower_zyx = np.maximum(nonzero.min(axis=0).astype(float) - padding_voxels, 0.0)
+    upper_zyx = nonzero.max(axis=0).astype(float) + padding_voxels
+    lower_xyz = lower_zyx[[2, 1, 0]] * resolution
+    upper_xyz = upper_zyx[[2, 1, 0]] * resolution
+    return lower_xyz, upper_xyz

--- a/src/napari_swc_viewer/db.py
+++ b/src/napari_swc_viewer/db.py
@@ -7,11 +7,13 @@ neuron data stored in Parquet format using DuckDB.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import duckdb
 import numpy as np
 import pandas as pd
+
+from .atlas_utils import mask_to_world_xyz_bounds, world_coords_xyz_to_atlas_voxels
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -334,6 +336,73 @@ class NeuronDatabase:
         stats["n_regions"] = result[0]
 
         return stats
+
+    def get_neurons_by_mask(
+        self,
+        mask_volume: NDArray[np.bool_] | NDArray[np.uint8] | np.ndarray,
+        atlas: Any,
+        soma_only: bool = False,
+    ) -> pd.DataFrame:
+        """Get neurons whose nodes fall inside a binary atlas-space mask."""
+        mask = np.asarray(mask_volume) > 0
+        if mask.ndim != 3:
+            raise ValueError(f"Expected a 3D mask volume, got shape {mask.shape}")
+
+        atlas_shape = tuple(np.asarray(atlas.annotation).shape)
+        if mask.shape != atlas_shape:
+            raise ValueError(
+                f"Mask shape {mask.shape} does not match atlas shape {atlas_shape}"
+            )
+
+        bounds = mask_to_world_xyz_bounds(mask, atlas)
+        if bounds is None:
+            return pd.DataFrame(columns=["file_id", "neuron_id", "subject"])
+
+        lower_xyz, upper_xyz = bounds
+        where_parts = [
+            "x >= ?",
+            "x <= ?",
+            "y >= ?",
+            "y <= ?",
+            "z >= ?",
+            "z <= ?",
+        ]
+        params: list[object] = [
+            float(lower_xyz[0]),
+            float(upper_xyz[0]),
+            float(lower_xyz[1]),
+            float(upper_xyz[1]),
+            float(lower_xyz[2]),
+            float(upper_xyz[2]),
+        ]
+        if soma_only:
+            where_parts.append("type = 1")
+
+        query = f"""
+            SELECT file_id, neuron_id, subject, x, y, z
+            FROM neurons
+            WHERE {' AND '.join(where_parts)}
+            ORDER BY file_id
+        """
+        candidates = self.conn.execute(query, params).fetchdf()
+        if candidates.empty:
+            return pd.DataFrame(columns=["file_id", "neuron_id", "subject"])
+
+        coords = candidates[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
+        voxel_coords = world_coords_xyz_to_atlas_voxels(coords, atlas)
+        in_bounds = np.all(
+            (voxel_coords >= 0) & (voxel_coords < np.asarray(mask.shape)),
+            axis=1,
+        )
+        hits = np.zeros(len(candidates), dtype=bool)
+        valid = voxel_coords[in_bounds]
+        if len(valid) > 0:
+            hits[in_bounds] = mask[valid[:, 0], valid[:, 1], valid[:, 2]]
+
+        matched = candidates.loc[hits, ["file_id", "neuron_id", "subject"]]
+        if matched.empty:
+            return pd.DataFrame(columns=["file_id", "neuron_id", "subject"])
+        return matched.drop_duplicates().sort_values("file_id").reset_index(drop=True)
 
     def get_region_neuron_counts(self) -> pd.DataFrame:
         """Get neuron counts per region.

--- a/src/napari_swc_viewer/point_import.py
+++ b/src/napari_swc_viewer/point_import.py
@@ -1,4 +1,4 @@
-"""Standard point Parquet import and CSV normalization utilities."""
+"""Standard point Parquet import, heatmap generation, and CSV normalization."""
 
 from __future__ import annotations
 
@@ -304,9 +304,7 @@ def _world_coords_to_atlas_region_ids(
     """Map world-space XYZ micron coordinates to atlas annotation region IDs."""
 
     annotation = np.asarray(atlas.annotation)
-    resolution = np.asarray(atlas.resolution, dtype=float)
-    lookup_coords = np.asarray(coords_xyz, dtype=float)[:, [2, 1, 0]]
-    voxel_coords = np.round(lookup_coords / resolution).astype(int)
+    voxel_coords = _world_coords_to_atlas_voxel_coords(coords_xyz, atlas)
 
     region_ids = np.zeros(len(voxel_coords), dtype=np.int64)
     in_bounds = np.all(
@@ -317,6 +315,17 @@ def _world_coords_to_atlas_region_ids(
     if len(valid) > 0:
         region_ids[in_bounds] = annotation[valid[:, 0], valid[:, 1], valid[:, 2]]
     return region_ids
+
+
+def _world_coords_to_atlas_voxel_coords(
+    coords_xyz: np.ndarray,
+    atlas: Any,
+) -> np.ndarray:
+    """Convert world-space XYZ micron coordinates to atlas ZYX voxel indices."""
+
+    resolution = np.asarray(atlas.resolution, dtype=float)
+    lookup_coords = np.asarray(coords_xyz, dtype=float)[:, [2, 1, 0]]
+    return np.round(lookup_coords / resolution).astype(int)
 
 
 def validate_point_metadata_against_atlas(
@@ -465,3 +474,31 @@ def dataframe_to_point_properties(df: pd.DataFrame) -> dict[str, list[Any]]:
         properties[column] = values
     return properties
 
+
+def build_label_heatmap_volumes(
+    df: pd.DataFrame,
+    atlas: Any,
+) -> dict[str, np.ndarray]:
+    """Build one dense atlas-space count volume per label."""
+
+    standardized = validate_standard_point_dataframe(df)
+    coords = standardized[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
+    voxel_coords = _world_coords_to_atlas_voxel_coords(coords, atlas)
+    atlas_shape = np.asarray(atlas.annotation.shape)
+    in_bounds = np.all((voxel_coords >= 0) & (voxel_coords < atlas_shape), axis=1)
+
+    volumes: dict[str, np.ndarray] = {}
+    labels = standardized["label"].tolist()
+    for label in dict.fromkeys(labels):
+        label_mask = standardized["label"].eq(label).to_numpy() & in_bounds
+        volume = np.zeros(atlas.annotation.shape, dtype=np.float32)
+        label_voxels = voxel_coords[label_mask]
+        if len(label_voxels) > 0:
+            np.add.at(
+                volume,
+                (label_voxels[:, 0], label_voxels[:, 1], label_voxels[:, 2]),
+                1.0,
+            )
+        volumes[str(label)] = volume
+
+    return volumes

--- a/src/napari_swc_viewer/point_import.py
+++ b/src/napari_swc_viewer/point_import.py
@@ -1,0 +1,467 @@
+"""Standard point Parquet import and CSV normalization utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .hemisphere import get_atlas_midline
+
+REQUIRED_POINT_COLUMNS = ("label", "x", "y", "z")
+OPTIONAL_POINT_COLUMNS = ("region_name", "acronym", "id", "hemisphere")
+STANDARD_POINT_COLUMNS = REQUIRED_POINT_COLUMNS + OPTIONAL_POINT_COLUMNS
+
+_STRING_OPTIONAL_COLUMNS = ("region_name", "acronym", "hemisphere")
+
+
+class PointImportError(ValueError):
+    """Raised when a point import file or mapping is invalid."""
+
+
+@dataclass(frozen=True)
+class AtlasValidationSummary:
+    """Summary of optional metadata validation against an atlas."""
+
+    total_points: int
+    checked_fields: tuple[str, ...]
+    mismatch_counts: dict[str, int]
+    mismatches: pd.DataFrame
+
+    @property
+    def total_mismatched_rows(self) -> int:
+        return int(len(self.mismatches))
+
+    @property
+    def has_mismatches(self) -> bool:
+        return self.total_mismatched_rows > 0
+
+
+def _empty_string_series(length: int) -> pd.Series:
+    return pd.Series(pd.array([pd.NA] * length, dtype="string"))
+
+
+def _empty_int_series(length: int) -> pd.Series:
+    return pd.Series(pd.array([pd.NA] * length, dtype="Int64"))
+
+
+def _normalize_string_series(series: pd.Series) -> pd.Series:
+    def normalize(value: Any) -> Any:
+        if pd.isna(value):
+            return pd.NA
+        return str(value)
+
+    return series.map(normalize).astype("string")
+
+
+def _nonempty_string_mask(series: pd.Series) -> pd.Series:
+    normalized = _normalize_string_series(series)
+    return normalized.notna() & normalized.str.strip().ne("")
+
+
+def _normalize_region_name(value: Any) -> str:
+    if pd.isna(value):
+        return ""
+    text = str(value).lower().replace("/", ", ")
+    text = re.sub(r"\s+", " ", text).strip(" ,")
+    return text
+
+
+def _compare_string_series(left: pd.Series, right: pd.Series) -> pd.Series:
+    left_norm = _normalize_string_series(left).str.strip()
+    right_norm = _normalize_string_series(right).str.strip()
+    return left_norm == right_norm
+
+
+def _compare_region_name_series(left: pd.Series, right: pd.Series) -> pd.Series:
+    return left.map(_normalize_region_name) == right.map(_normalize_region_name)
+
+
+def _compare_hemisphere_series(left: pd.Series, right: pd.Series) -> pd.Series:
+    return (
+        _normalize_string_series(left).str.strip().str.lower()
+        == _normalize_string_series(right).str.strip().str.lower()
+    )
+
+
+def load_column_mapping(mapping_path: str | Path) -> dict[str, str]:
+    """Load and validate a target-to-source JSON column mapping."""
+
+    path = Path(mapping_path)
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise PointImportError(f"Mapping file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PointImportError(f"Invalid JSON in mapping file: {path}") from exc
+
+    if not isinstance(data, dict):
+        raise PointImportError("Mapping file must contain a single JSON object.")
+
+    unknown_targets = sorted(set(data) - set(STANDARD_POINT_COLUMNS))
+    if unknown_targets:
+        targets = ", ".join(unknown_targets)
+        raise PointImportError(f"Unknown mapping target column(s): {targets}")
+
+    mapping: dict[str, str] = {}
+    for target, source in data.items():
+        if not isinstance(source, str) or not source.strip():
+            raise PointImportError(
+                f"Mapping for '{target}' must be a non-empty source column name."
+            )
+        mapping[str(target)] = source.strip()
+
+    missing_required = [
+        column for column in REQUIRED_POINT_COLUMNS if column not in mapping
+    ]
+    if missing_required:
+        columns = ", ".join(missing_required)
+        raise PointImportError(f"Missing required mapping(s): {columns}")
+
+    duplicate_sources = sorted(
+        source
+        for source in set(mapping.values())
+        if list(mapping.values()).count(source) > 1
+    )
+    if duplicate_sources:
+        sources = ", ".join(duplicate_sources)
+        raise PointImportError(
+            f"Source columns cannot be mapped more than once: {sources}"
+        )
+
+    return mapping
+
+
+def validate_standard_point_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and normalize a standardized point dataframe."""
+
+    missing_required = [
+        column for column in REQUIRED_POINT_COLUMNS if column not in df.columns
+    ]
+    if missing_required:
+        columns = ", ".join(missing_required)
+        raise PointImportError(f"Missing required point column(s): {columns}")
+
+    normalized = df.copy()
+    extras = [
+        column for column in normalized.columns if column not in STANDARD_POINT_COLUMNS
+    ]
+
+    labels = _normalize_string_series(normalized["label"]).str.strip()
+    invalid_labels = labels.isna() | labels.eq("")
+    if invalid_labels.any():
+        count = int(invalid_labels.sum())
+        raise PointImportError(f"Column 'label' has {count} empty value(s).")
+    normalized["label"] = labels
+
+    for column in ("x", "y", "z"):
+        values = pd.to_numeric(normalized[column], errors="coerce")
+        invalid = values.isna()
+        if invalid.any():
+            count = int(invalid.sum())
+            raise PointImportError(f"Column '{column}' has {count} invalid value(s).")
+        normalized[column] = values.astype(float)
+
+    for column in _STRING_OPTIONAL_COLUMNS:
+        if column not in normalized.columns:
+            normalized[column] = _empty_string_series(len(normalized))
+        else:
+            normalized[column] = _normalize_string_series(normalized[column])
+
+    if "id" not in normalized.columns:
+        normalized["id"] = _empty_int_series(len(normalized))
+    else:
+        id_series = normalized["id"]
+        if pd.api.types.is_string_dtype(id_series) or id_series.dtype == object:
+            blanks = _normalize_string_series(id_series).str.strip().eq("")
+            id_series = id_series.where(~blanks, pd.NA)
+        values = pd.to_numeric(id_series, errors="coerce")
+        invalid = pd.Series(False, index=normalized.index)
+        invalid |= values.isna() & id_series.notna()
+        if invalid.any():
+            count = int(invalid.sum())
+            raise PointImportError(f"Column 'id' has {count} invalid value(s).")
+        normalized["id"] = values.astype("Int64")
+
+    ordered_columns = [*STANDARD_POINT_COLUMNS, *extras]
+    return normalized[ordered_columns]
+
+
+def standardize_point_dataframe(
+    raw_df: pd.DataFrame,
+    mapping: dict[str, str],
+) -> pd.DataFrame:
+    """Apply a target-to-source mapping to produce a standardized dataframe."""
+
+    missing_sources = sorted(set(mapping.values()) - set(raw_df.columns))
+    if missing_sources:
+        columns = ", ".join(missing_sources)
+        raise PointImportError(f"Mapped source column(s) not found in CSV: {columns}")
+
+    mapped_sources = set(mapping.values())
+    conflicting_extras = sorted(
+        column
+        for column in raw_df.columns
+        if column not in mapped_sources and column in STANDARD_POINT_COLUMNS
+    )
+    if conflicting_extras:
+        columns = ", ".join(conflicting_extras)
+        raise PointImportError(
+            "Unmapped source columns conflict with standardized column names: "
+            f"{columns}"
+        )
+
+    standardized = pd.DataFrame(index=raw_df.index)
+    for column in REQUIRED_POINT_COLUMNS:
+        standardized[column] = raw_df[mapping[column]]
+
+    for column in OPTIONAL_POINT_COLUMNS:
+        if column in mapping:
+            standardized[column] = raw_df[mapping[column]]
+        elif column == "id":
+            standardized[column] = _empty_int_series(len(raw_df))
+        else:
+            standardized[column] = _empty_string_series(len(raw_df))
+
+    for column in raw_df.columns:
+        if column not in mapped_sources:
+            standardized[column] = raw_df[column]
+
+    return validate_standard_point_dataframe(standardized)
+
+
+def load_raw_point_csv(csv_path: str | Path) -> pd.DataFrame:
+    """Load a raw point CSV file."""
+
+    path = Path(csv_path)
+    try:
+        return pd.read_csv(path)
+    except FileNotFoundError as exc:
+        raise PointImportError(f"CSV file not found: {path}") from exc
+
+
+def convert_point_csv_to_parquet(
+    csv_path: str | Path,
+    mapping_path: str | Path,
+    output_path: str | Path,
+) -> pd.DataFrame:
+    """Convert a raw point CSV plus mapping JSON into standardized Parquet."""
+
+    raw_df = load_raw_point_csv(csv_path)
+    mapping = load_column_mapping(mapping_path)
+    standardized = standardize_point_dataframe(raw_df, mapping)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    standardized.to_parquet(output_path, index=False)
+    return standardized
+
+
+def load_standard_point_parquet(parquet_path: str | Path) -> pd.DataFrame:
+    """Load and validate a standardized point Parquet file."""
+
+    path = Path(parquet_path)
+    try:
+        df = pd.read_parquet(path)
+    except FileNotFoundError as exc:
+        raise PointImportError(f"Point Parquet file not found: {path}") from exc
+    except Exception as exc:
+        raise PointImportError(f"Failed to read Point Parquet file: {path}") from exc
+    return validate_standard_point_dataframe(df)
+
+
+def _build_region_lookup(atlas: Any) -> dict[int, dict[str, Any]]:
+    """Build a simple region metadata lookup from a BrainGlobe atlas."""
+
+    lookup: dict[int, dict[str, Any]] = {}
+    structures = getattr(atlas, "structures", {})
+    for key, structure in structures.items():
+        if not isinstance(key, int):
+            continue
+        try:
+            name = structure["name"]
+        except Exception:
+            name = getattr(structure, "name", "")
+        try:
+            acronym = structure["acronym"]
+        except Exception:
+            acronym = getattr(structure, "acronym", "")
+        lookup[int(key)] = {
+            "id": int(key),
+            "name": str(name),
+            "acronym": str(acronym),
+        }
+    return lookup
+
+
+def _world_coords_to_atlas_region_ids(
+    coords_xyz: np.ndarray,
+    atlas: Any,
+) -> np.ndarray:
+    """Map world-space XYZ micron coordinates to atlas annotation region IDs."""
+
+    annotation = np.asarray(atlas.annotation)
+    resolution = np.asarray(atlas.resolution, dtype=float)
+    lookup_coords = np.asarray(coords_xyz, dtype=float)[:, [2, 1, 0]]
+    voxel_coords = np.round(lookup_coords / resolution).astype(int)
+
+    region_ids = np.zeros(len(voxel_coords), dtype=np.int64)
+    in_bounds = np.all(
+        (voxel_coords >= 0) & (voxel_coords < np.asarray(annotation.shape)),
+        axis=1,
+    )
+    valid = voxel_coords[in_bounds]
+    if len(valid) > 0:
+        region_ids[in_bounds] = annotation[valid[:, 0], valid[:, 1], valid[:, 2]]
+    return region_ids
+
+
+def validate_point_metadata_against_atlas(
+    df: pd.DataFrame,
+    atlas: Any,
+) -> AtlasValidationSummary:
+    """Validate optional point metadata columns against atlas-derived values."""
+
+    standardized = validate_standard_point_dataframe(df)
+    coords = standardized[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
+
+    region_ids = _world_coords_to_atlas_region_ids(coords, atlas)
+    lookup = _build_region_lookup(atlas)
+    derived_region_name = pd.Series(
+        [lookup.get(int(region_id), {}).get("name", "") for region_id in region_ids],
+        dtype="string",
+    )
+    derived_acronym = pd.Series(
+        [lookup.get(int(region_id), {}).get("acronym", "") for region_id in region_ids],
+        dtype="string",
+    )
+
+    midline = get_atlas_midline(atlas, coord_axis=2)
+    hemisphere_values = np.full(len(standardized), "midline", dtype=object)
+    hemisphere_values[coords[:, 2] < midline - 1.0] = "left"
+    hemisphere_values[coords[:, 2] > midline + 1.0] = "right"
+    derived_hemisphere = pd.Series(hemisphere_values, dtype="string")
+
+    compared_fields: list[str] = []
+    mismatch_counts: dict[str, int] = {}
+    row_mask = pd.Series(False, index=standardized.index)
+    mismatch_fields: dict[int, list[str]] = {}
+
+    def record_mismatches(field: str, mask: pd.Series) -> None:
+        mismatch_counts[field] = int(mask.sum())
+        if not mask.any():
+            return
+        for index in standardized.index[mask]:
+            mismatch_fields.setdefault(int(index), []).append(field)
+
+    if "id" in standardized.columns:
+        supplied = standardized["id"].notna()
+        if supplied.any():
+            compared_fields.append("id")
+            mismatch = supplied & (standardized["id"].astype("Int64") != region_ids)
+            row_mask |= mismatch
+            record_mismatches("id", mismatch)
+
+    if "acronym" in standardized.columns:
+        supplied = _nonempty_string_mask(standardized["acronym"])
+        if supplied.any():
+            compared_fields.append("acronym")
+            mismatch = supplied & ~_compare_string_series(
+                standardized["acronym"],
+                derived_acronym,
+            )
+            row_mask |= mismatch
+            record_mismatches("acronym", mismatch)
+
+    if "region_name" in standardized.columns:
+        supplied = _nonempty_string_mask(standardized["region_name"])
+        if supplied.any():
+            compared_fields.append("region_name")
+            mismatch = supplied & ~_compare_region_name_series(
+                standardized["region_name"],
+                derived_region_name,
+            )
+            row_mask |= mismatch
+            record_mismatches("region_name", mismatch)
+
+    if "hemisphere" in standardized.columns:
+        supplied = _nonempty_string_mask(standardized["hemisphere"])
+        if supplied.any():
+            compared_fields.append("hemisphere")
+            mismatch = supplied & ~_compare_hemisphere_series(
+                standardized["hemisphere"],
+                derived_hemisphere,
+            )
+            row_mask |= mismatch
+            record_mismatches("hemisphere", mismatch)
+
+    mismatch_df = standardized.loc[row_mask].copy()
+    mismatch_df["atlas_region_name"] = derived_region_name[row_mask].to_numpy()
+    mismatch_df["atlas_acronym"] = derived_acronym[row_mask].to_numpy()
+    mismatch_df["atlas_id"] = region_ids[row_mask.to_numpy()]
+    mismatch_df["atlas_hemisphere"] = derived_hemisphere[row_mask].to_numpy()
+    mismatch_df["mismatch_fields"] = [
+        ",".join(mismatch_fields[int(index)])
+        for index in mismatch_df.index
+    ]
+
+    return AtlasValidationSummary(
+        total_points=len(standardized),
+        checked_fields=tuple(compared_fields),
+        mismatch_counts=mismatch_counts,
+        mismatches=mismatch_df,
+    )
+
+
+def format_atlas_validation_summary(
+    summary: AtlasValidationSummary,
+    max_examples: int = 5,
+) -> str:
+    """Format a concise user-facing summary of atlas validation mismatches."""
+
+    if not summary.has_mismatches:
+        return (
+            f"Atlas validation checked {summary.total_points} point(s) and found "
+            "no mismatches."
+        )
+
+    count_bits = ", ".join(
+        f"{field}: {count}"
+        for field, count in summary.mismatch_counts.items()
+        if count > 0
+    )
+    message = (
+        f"Atlas validation found {summary.total_mismatched_rows} mismatched point(s) "
+        f"out of {summary.total_points}"
+    )
+    if count_bits:
+        message += f" ({count_bits})"
+    message += "."
+
+    examples: list[str] = []
+    for index, row in summary.mismatches.head(max_examples).iterrows():
+        label = row["label"]
+        fields = row["mismatch_fields"]
+        examples.append(f"row {int(index) + 1} label={label} [{fields}]")
+
+    if examples:
+        message += " Examples: " + "; ".join(examples)
+
+    return message
+
+
+def dataframe_to_point_properties(df: pd.DataFrame) -> dict[str, list[Any]]:
+    """Convert a point dataframe into napari point properties."""
+
+    properties: dict[str, list[Any]] = {}
+    for column in df.columns:
+        if column in {"x", "y", "z"}:
+            continue
+        series = df[column]
+        values = series.astype(object).where(series.notna(), None).tolist()
+        properties[column] = values
+    return properties
+

--- a/src/napari_swc_viewer/point_import.py
+++ b/src/napari_swc_viewer/point_import.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from .atlas_utils import world_coords_xyz_to_atlas_voxels
 from .hemisphere import get_atlas_midline
 
 REQUIRED_POINT_COLUMNS = ("label", "x", "y", "z")
@@ -304,7 +305,7 @@ def _world_coords_to_atlas_region_ids(
     """Map world-space XYZ micron coordinates to atlas annotation region IDs."""
 
     annotation = np.asarray(atlas.annotation)
-    voxel_coords = _world_coords_to_atlas_voxel_coords(coords_xyz, atlas)
+    voxel_coords = world_coords_xyz_to_atlas_voxels(coords_xyz, atlas)
 
     region_ids = np.zeros(len(voxel_coords), dtype=np.int64)
     in_bounds = np.all(
@@ -315,18 +316,6 @@ def _world_coords_to_atlas_region_ids(
     if len(valid) > 0:
         region_ids[in_bounds] = annotation[valid[:, 0], valid[:, 1], valid[:, 2]]
     return region_ids
-
-
-def _world_coords_to_atlas_voxel_coords(
-    coords_xyz: np.ndarray,
-    atlas: Any,
-) -> np.ndarray:
-    """Convert world-space XYZ micron coordinates to atlas ZYX voxel indices."""
-
-    resolution = np.asarray(atlas.resolution, dtype=float)
-    lookup_coords = np.asarray(coords_xyz, dtype=float)[:, [2, 1, 0]]
-    return np.round(lookup_coords / resolution).astype(int)
-
 
 def validate_point_metadata_against_atlas(
     df: pd.DataFrame,
@@ -483,7 +472,7 @@ def build_label_heatmap_volumes(
 
     standardized = validate_standard_point_dataframe(df)
     coords = standardized[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
-    voxel_coords = _world_coords_to_atlas_voxel_coords(coords, atlas)
+    voxel_coords = world_coords_xyz_to_atlas_voxels(coords, atlas)
     atlas_shape = np.asarray(atlas.annotation.shape)
     in_bounds = np.all((voxel_coords >= 0) & (voxel_coords < atlas_shape), axis=1)
 

--- a/src/napari_swc_viewer/widgets/analysis_tab.py
+++ b/src/napari_swc_viewer/widgets/analysis_tab.py
@@ -551,6 +551,16 @@ class AnalysisTabWidget(QWidget):
             opacity=0.7,
             visible=True,
             scale=scale,
+            metadata={
+                "heatmap_source": True,
+                "heatmap_native_grid": self._pending_heatmap_depth_bin == 1,
+                "atlas_name": getattr(self._atlas, "atlas_name", None),
+                "heatmap_kind": "analysis",
+                "heatmap_region": region,
+                "heatmap_cluster": cluster_label,
+                "depth_bin_factor": self._pending_heatmap_depth_bin,
+                "depth_axis": self._pending_heatmap_depth_axis,
+            },
         )
 
     def _on_error(self, message: str) -> None:

--- a/src/napari_swc_viewer/widgets/mask_layer_selector.py
+++ b/src/napari_swc_viewer/widgets/mask_layer_selector.py
@@ -1,0 +1,131 @@
+"""Widget for selecting generated mask layers with checkboxes."""
+
+from __future__ import annotations
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class MaskLayerSelectorWidget(QWidget):
+    """Widget for selecting generated mask layers for querying."""
+
+    selection_changed = Signal(list)
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+        self._items_by_name: dict[str, QTreeWidgetItem] = {}
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the widget UI."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        search_layout = QHBoxLayout()
+        self._search_input = QLineEdit()
+        self._search_input.setPlaceholderText("Search mask layers...")
+        self._search_input.textChanged.connect(self._on_search_changed)
+        search_layout.addWidget(self._search_input)
+
+        self._clear_search_btn = QPushButton("Clear")
+        self._clear_search_btn.clicked.connect(self._clear_search)
+        search_layout.addWidget(self._clear_search_btn)
+        layout.addLayout(search_layout)
+
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(["Mask Layer", "Source Heatmaps"])
+        self._tree.setColumnWidth(0, 220)
+        self._tree.itemChanged.connect(self._on_item_changed)
+        layout.addWidget(self._tree)
+
+        info_layout = QHBoxLayout()
+        self._selection_label = QLabel("Selected: 0 mask layers")
+        info_layout.addWidget(self._selection_label)
+
+        self._clear_btn = QPushButton("Clear Selection")
+        self._clear_btn.clicked.connect(self._clear_selection)
+        info_layout.addWidget(self._clear_btn)
+        layout.addLayout(info_layout)
+
+    def set_mask_layers(self, masks: list[dict[str, object]]) -> None:
+        """Populate the selector with mask layer metadata."""
+        checked_names = set(self.get_selected_layer_names())
+        self._tree.blockSignals(True)
+        self._tree.clear()
+        self._items_by_name.clear()
+
+        for mask in masks:
+            name = str(mask.get("name", ""))
+            sources = mask.get("sources", [])
+            if isinstance(sources, (list, tuple)):
+                source_text = ", ".join(str(value) for value in sources)
+            else:
+                source_text = str(sources)
+
+            item = QTreeWidgetItem(self._tree, [name, source_text])
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(0, Qt.Checked if name in checked_names else Qt.Unchecked)
+            item.setData(0, Qt.UserRole, name)
+            self._items_by_name[name] = item
+
+        self._tree.blockSignals(False)
+        self._update_selection_label()
+        self._emit_selection_changed()
+
+    def _on_item_changed(self, item: QTreeWidgetItem, column: int) -> None:
+        """Handle checkbox changes."""
+        if column != 0:
+            return
+        self._update_selection_label()
+        self._emit_selection_changed()
+
+    def _on_search_changed(self, text: str) -> None:
+        """Filter rows based on search text."""
+        pattern = text.lower().strip()
+        for item in self._items_by_name.values():
+            name = item.text(0).lower()
+            sources = item.text(1).lower()
+            visible = not pattern or pattern in name or pattern in sources
+            item.setHidden(not visible)
+
+    def _clear_search(self) -> None:
+        """Clear the search filter."""
+        self._search_input.clear()
+        for item in self._items_by_name.values():
+            item.setHidden(False)
+
+    def _clear_selection(self) -> None:
+        """Clear all selected mask layers."""
+        self._tree.blockSignals(True)
+        for item in self._items_by_name.values():
+            item.setCheckState(0, Qt.Unchecked)
+        self._tree.blockSignals(False)
+        self._update_selection_label()
+        self._emit_selection_changed()
+
+    def _update_selection_label(self) -> None:
+        """Update the selection count label."""
+        self._selection_label.setText(
+            f"Selected: {len(self.get_selected_layer_names())} mask layers"
+        )
+
+    def _emit_selection_changed(self) -> None:
+        """Emit the selection_changed signal with selected mask layer names."""
+        self.selection_changed.emit(self.get_selected_layer_names())
+
+    def get_selected_layer_names(self) -> list[str]:
+        """Return the checked mask layer names."""
+        names = []
+        for name, item in self._items_by_name.items():
+            if item.checkState(0) == Qt.Checked:
+                names.append(name)
+        return sorted(names)

--- a/src/napari_swc_viewer/widgets/neuron_viewer.py
+++ b/src/napari_swc_viewer/widgets/neuron_viewer.py
@@ -42,7 +42,7 @@ from ..auto_center import (
 from ..db import NeuronDatabase
 from ..point_import import (
     PointImportError,
-    dataframe_to_point_properties,
+    build_label_heatmap_volumes,
     format_atlas_validation_summary,
     load_standard_point_parquet,
     validate_point_metadata_against_atlas,
@@ -573,7 +573,7 @@ class NeuronViewerWidget(QWidget):
         self._load_point_parquet_file(filepath)
 
     def _load_point_parquet_file(self, filepath: str) -> None:
-        """Load standardized point Parquet and add one layer per label."""
+        """Load standardized point Parquet and add one heatmap layer per label."""
         if self._atlas is None:
             message = "Load an atlas before importing point Parquet."
             self._point_import_status_label.setText(message)
@@ -599,33 +599,37 @@ class NeuronViewerWidget(QWidget):
         if validation_summary.has_mismatches:
             show_warning(format_atlas_validation_summary(validation_summary))
 
-        scale = [1.0 / res for res in self._atlas.resolution]
         opacity = self._opacity_slider.value() / 100.0
-        label_order = list(dict.fromkeys(points_df["label"].tolist()))
+        label_heatmaps = build_label_heatmap_volumes(points_df, self._atlas)
 
-        for label in label_order:
+        for label, volume in label_heatmaps.items():
+            layer_name = f"Points Heatmap: {label}"
+            for layer in list(self.viewer.layers):
+                if layer.name == layer_name:
+                    self.viewer.layers.remove(layer)
+
             label_df = points_df.loc[points_df["label"] == label]
-            coords = label_df[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
-            properties = dataframe_to_point_properties(label_df)
-
-            self.viewer.add_points(
-                coords,
-                size=self._point_size_spin.value(),
-                name=f"Points: {label}",
+            nonzero_voxels = int((volume > 0).sum())
+            self.viewer.add_image(
+                volume,
+                name=layer_name,
+                blending="additive",
+                rendering="mip",
+                colormap="hot",
                 opacity=opacity,
-                scale=scale,
-                properties=properties,
                 metadata={
                     "source_path": filepath,
                     "label": label,
                     "point_count": len(label_df),
+                    "nonzero_voxels": nonzero_voxels,
+                    "columns": list(label_df.columns),
                 },
             )
 
         self._point_file_label.setText(Path(filepath).name)
         message = (
-            f"Imported {len(points_df):,} point(s) across {len(label_order)} "
-            f"label(s)."
+            f"Imported {len(points_df):,} point(s) into {len(label_heatmaps)} "
+            f"heatmap layer(s)."
         )
         if validation_summary.has_mismatches:
             message += (
@@ -636,7 +640,7 @@ class NeuronViewerWidget(QWidget):
         logger.info(
             "Imported point Parquet %s with %d labels and %d points",
             filepath,
-            len(label_order),
+            len(label_heatmaps),
             len(points_df),
         )
 

--- a/src/napari_swc_viewer/widgets/neuron_viewer.py
+++ b/src/napari_swc_viewer/widgets/neuron_viewer.py
@@ -9,6 +9,7 @@ This widget provides a unified interface for:
 
 from __future__ import annotations
 
+import colorsys
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -64,6 +65,28 @@ if TYPE_CHECKING:
     import napari
 
 logger = logging.getLogger(__name__)
+
+_POINT_HEATMAP_BASE_COLORS = [
+    (1.0, 0.0, 0.0, 1.0),    # red
+    (0.0, 0.8, 0.0, 1.0),    # green
+    (1.0, 0.9, 0.0, 1.0),    # yellow
+    (0.1, 0.4, 1.0, 1.0),    # blue
+    (1.0, 0.4, 0.0, 1.0),    # orange
+    (0.8, 0.0, 0.8, 1.0),    # magenta
+    (0.0, 0.8, 0.8, 1.0),    # cyan
+    (0.6, 0.3, 0.0, 1.0),    # brown
+]
+
+
+def _point_heatmap_color(index: int) -> tuple[float, float, float, float]:
+    """Return a distinct RGBA color for a heatmap layer."""
+    if index < len(_POINT_HEATMAP_BASE_COLORS):
+        return _POINT_HEATMAP_BASE_COLORS[index]
+
+    # Spread additional labels across the hue wheel to avoid reusing colors.
+    hue = (index * 0.618033988749895) % 1.0
+    red, green, blue = colorsys.hsv_to_rgb(hue, 0.85, 1.0)
+    return (red, green, blue, 1.0)
 
 
 class NeuronViewerWidget(QWidget):
@@ -574,6 +597,8 @@ class NeuronViewerWidget(QWidget):
 
     def _load_point_parquet_file(self, filepath: str) -> None:
         """Load standardized point Parquet and add one heatmap layer per label."""
+        from napari.utils.colormaps import Colormap
+
         if self._atlas is None:
             message = "Load an atlas before importing point Parquet."
             self._point_import_status_label.setText(message)
@@ -602,7 +627,7 @@ class NeuronViewerWidget(QWidget):
         opacity = self._opacity_slider.value() / 100.0
         label_heatmaps = build_label_heatmap_volumes(points_df, self._atlas)
 
-        for label, volume in label_heatmaps.items():
+        for color_idx, (label, volume) in enumerate(label_heatmaps.items()):
             layer_name = f"Points Heatmap: {label}"
             for layer in list(self.viewer.layers):
                 if layer.name == layer_name:
@@ -610,12 +635,17 @@ class NeuronViewerWidget(QWidget):
 
             label_df = points_df.loc[points_df["label"] == label]
             nonzero_voxels = int((volume > 0).sum())
+            rgba = _point_heatmap_color(color_idx)
+            colormap = Colormap(
+                colors=[[0.0, 0.0, 0.0, 0.0], list(rgba)],
+                name=f"point_heatmap_{color_idx}",
+            )
             self.viewer.add_image(
                 volume,
                 name=layer_name,
                 blending="additive",
                 rendering="mip",
-                colormap="hot",
+                colormap=colormap,
                 opacity=opacity,
                 metadata={
                     "source_path": filepath,
@@ -623,6 +653,7 @@ class NeuronViewerWidget(QWidget):
                     "point_count": len(label_df),
                     "nonzero_voxels": nonzero_voxels,
                     "columns": list(label_df.columns),
+                    "color": rgba,
                 },
             )
 

--- a/src/napari_swc_viewer/widgets/neuron_viewer.py
+++ b/src/napari_swc_viewer/widgets/neuron_viewer.py
@@ -19,22 +19,27 @@ from brainglobe_atlasapi import BrainGlobeAtlas
 from napari.utils.notifications import show_info, show_warning
 from qtpy.QtCore import Qt, QThread, QTimer
 from qtpy.QtWidgets import (
+    QAbstractItemView,
     QApplication,
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFileDialog,
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QListWidget,
     QProgressBar,
     QPushButton,
     QSlider,
     QSpinBox,
+    QStackedWidget,
     QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from ..analysis.mask import build_binary_mask_from_heatmap, merge_heatmap_volumes
 from ..auto_center import (
     center_to_depth_world,
     compute_center_of_rendered_neurons,
@@ -57,6 +62,7 @@ from .reference_layers import (
     remove_region_segmentation,
 )
 from .analysis_tab import AnalysisTabWidget
+from .mask_layer_selector import MaskLayerSelectorWidget
 from .neuron_table import NeuronTableWidget
 from .region_selector import RegionSelectorWidget
 from .slice_projection import NeuronSliceProjector
@@ -89,6 +95,37 @@ def _point_heatmap_color(index: int) -> tuple[float, float, float, float]:
     return (red, green, blue, 1.0)
 
 
+def _layer_metadata(layer) -> dict:
+    """Return layer metadata as a mutable dict-like object."""
+    metadata = getattr(layer, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _mask_layer_color(source_layers: list) -> tuple[float, float, float, float] | None:
+    """Derive a labels-layer color from source heatmap metadata."""
+    colors = []
+    for layer in source_layers:
+        color = _layer_metadata(layer).get("color")
+        if color is None:
+            continue
+        rgba = np.asarray(color, dtype=float).reshape(-1)
+        if rgba.size == 3:
+            rgba = np.append(rgba, 1.0)
+        if rgba.size >= 4:
+            colors.append(rgba[:4])
+
+    if not colors:
+        return None
+
+    if len(colors) == 1:
+        rgba = colors[0]
+    else:
+        rgba = np.mean(np.vstack(colors), axis=0)
+        rgba[3] = 1.0
+    rgba = np.clip(rgba, 0.0, 1.0)
+    return tuple(float(value) for value in rgba[:4])
+
+
 class NeuronViewerWidget(QWidget):
     """Main widget for viewing neurons with brain region filtering.
 
@@ -114,6 +151,7 @@ class NeuronViewerWidget(QWidget):
         self._highlighted_file_ids: set[str] | None = None  # None = no highlight
         self._last_soma_selection: set = set()  # track to skip no-op highlights
         self._auto_center_applied_once = False
+        self._region_query_source = "Atlas Regions"
 
         # Slice projection for 2D viewing
         self._slice_projector = NeuronSliceProjector(napari_viewer, tolerance=100.0)
@@ -123,6 +161,9 @@ class NeuronViewerWidget(QWidget):
         self._convert_worker = None
 
         self._setup_ui()
+        self._connect_layer_events()
+        self._refresh_heatmap_layer_list()
+        self._refresh_mask_layer_options()
 
         # Auto-hide neuron line layers in 2D mode
         self.viewer.dims.events.ndisplay.connect(self._on_ndisplay_changed)
@@ -166,6 +207,10 @@ class NeuronViewerWidget(QWidget):
         )
         tabs.addTab(self._analysis_tab, "Analysis")
 
+        tools_tab = QWidget()
+        tabs.addTab(tools_tab, "Tools")
+        self._setup_tools_tab(tools_tab)
+
     def _setup_data_tab(self, parent: QWidget) -> None:
         """Set up the data loading tab."""
         layout = QVBoxLayout(parent)
@@ -202,7 +247,7 @@ class NeuronViewerWidget(QWidget):
         layout.addWidget(convert_group)
 
         # File selection
-        file_group = QGroupBox("Parquet Data")
+        file_group = QGroupBox("SWC Parquet Data")
         file_layout = QVBoxLayout(file_group)
 
         file_row = QHBoxLayout()
@@ -344,18 +389,140 @@ class NeuronViewerWidget(QWidget):
         """Set up the region selection tab."""
         layout = QVBoxLayout(parent)
 
-        # Region selector widget
+        source_row = QHBoxLayout()
+        source_row.addWidget(QLabel("Query source:"))
+        self._region_query_source_combo = QComboBox()
+        self._region_query_source_combo.addItems(["Atlas Regions", "Mask Layer"])
+        self._region_query_source_combo.currentTextChanged.connect(
+            self._on_region_query_source_changed
+        )
+        source_row.addWidget(self._region_query_source_combo)
+        layout.addLayout(source_row)
+
+        self._region_query_stack = QStackedWidget()
+
+        atlas_page = QWidget()
+        atlas_layout = QVBoxLayout(atlas_page)
+        atlas_layout.setContentsMargins(0, 0, 0, 0)
         self._region_selector = RegionSelectorWidget()
         self._region_selector.selection_changed.connect(self._on_regions_selected)
-        layout.addWidget(self._region_selector)
+        atlas_layout.addWidget(self._region_selector)
+        self._region_query_stack.addWidget(atlas_page)
+
+        mask_page = QWidget()
+        mask_layout = QVBoxLayout(mask_page)
+        mask_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._mask_layer_selector = MaskLayerSelectorWidget()
+        self._mask_layer_selector.selection_changed.connect(
+            self._on_mask_layer_selection_changed
+        )
+        mask_layout.addWidget(self._mask_layer_selector)
+
+        membership_row = QHBoxLayout()
+        membership_row.addWidget(QLabel("Membership:"))
+        self._mask_query_membership_combo = QComboBox()
+        self._mask_query_membership_combo.addItem("Any node in mask", False)
+        self._mask_query_membership_combo.addItem("Soma in mask", True)
+        membership_row.addWidget(self._mask_query_membership_combo)
+        mask_layout.addLayout(membership_row)
+
+        self._mask_query_hint_label = QLabel("")
+        self._mask_query_hint_label.setWordWrap(True)
+        mask_layout.addWidget(self._mask_query_hint_label)
+        mask_layout.addStretch()
+        self._region_query_stack.addWidget(mask_page)
+
+        layout.addWidget(self._region_query_stack)
 
         # Query button
         btn_row = QHBoxLayout()
         self._query_btn = QPushButton("Find Neurons in Selected Regions")
-        self._query_btn.clicked.connect(self._query_neurons_by_region)
+        self._query_btn.clicked.connect(self._query_neurons)
         self._query_btn.setEnabled(False)
         btn_row.addWidget(self._query_btn)
         layout.addLayout(btn_row)
+
+        self._regions_status_label = QLabel("")
+        self._regions_status_label.setWordWrap(True)
+        layout.addWidget(self._regions_status_label)
+        self._on_region_query_source_changed(self._region_query_source_combo.currentText())
+
+    def _setup_tools_tab(self, parent: QWidget) -> None:
+        """Set up the heatmap-to-mask tools tab."""
+        layout = QVBoxLayout(parent)
+
+        sources_group = QGroupBox("Heatmap Sources")
+        sources_layout = QVBoxLayout(sources_group)
+        self._heatmap_layer_list = QListWidget()
+        self._heatmap_layer_list.setSelectionMode(
+            QAbstractItemView.ExtendedSelection
+        )
+        sources_layout.addWidget(self._heatmap_layer_list)
+        self._tools_hint_label = QLabel("")
+        self._tools_hint_label.setWordWrap(True)
+        sources_layout.addWidget(self._tools_hint_label)
+        layout.addWidget(sources_group)
+
+        settings_group = QGroupBox("Mask Creation")
+        settings_layout = QVBoxLayout(settings_group)
+
+        mode_row = QHBoxLayout()
+        mode_row.addWidget(QLabel("Output mode:"))
+        self._mask_output_mode_combo = QComboBox()
+        self._mask_output_mode_combo.addItems(["Separate masks", "Merged mask"])
+        mode_row.addWidget(self._mask_output_mode_combo)
+        settings_layout.addLayout(mode_row)
+
+        sigma_row = QHBoxLayout()
+        self._mask_sigma_label = QLabel("Gaussian sigma (voxels):")
+        sigma_row.addWidget(self._mask_sigma_label)
+        self._mask_sigma_spin = QDoubleSpinBox()
+        self._mask_sigma_spin.setRange(0.0, 20.0)
+        self._mask_sigma_spin.setDecimals(2)
+        self._mask_sigma_spin.setSingleStep(0.25)
+        self._mask_sigma_spin.setValue(1.0)
+        sigma_row.addWidget(self._mask_sigma_spin)
+        settings_layout.addLayout(sigma_row)
+        self._mask_sigma_units_label = QLabel(
+            "1 voxel = atlas voxel size; load an atlas to see the micron equivalent."
+        )
+        self._mask_sigma_units_label.setWordWrap(True)
+        settings_layout.addWidget(self._mask_sigma_units_label)
+
+        threshold_row = QHBoxLayout()
+        threshold_row.addWidget(QLabel("Threshold:"))
+        self._mask_threshold_mode_combo = QComboBox()
+        self._mask_threshold_mode_combo.addItems(["Otsu", "Manual"])
+        self._mask_threshold_mode_combo.currentTextChanged.connect(
+            self._on_mask_threshold_mode_changed
+        )
+        threshold_row.addWidget(self._mask_threshold_mode_combo)
+        settings_layout.addLayout(threshold_row)
+
+        manual_row = QHBoxLayout()
+        manual_row.addWidget(QLabel("Manual value:"))
+        self._mask_manual_threshold_spin = QDoubleSpinBox()
+        self._mask_manual_threshold_spin.setRange(-1_000_000.0, 1_000_000.0)
+        self._mask_manual_threshold_spin.setDecimals(4)
+        self._mask_manual_threshold_spin.setValue(1.0)
+        manual_row.addWidget(self._mask_manual_threshold_spin)
+        settings_layout.addLayout(manual_row)
+
+        self._create_mask_btn = QPushButton("Create Mask Layer")
+        self._create_mask_btn.clicked.connect(self._create_masks_from_heatmaps)
+        settings_layout.addWidget(self._create_mask_btn)
+
+        self._tools_status_label = QLabel("")
+        self._tools_status_label.setWordWrap(True)
+        settings_layout.addWidget(self._tools_status_label)
+
+        layout.addWidget(settings_group)
+        layout.addStretch()
+        self._on_mask_threshold_mode_changed(
+            self._mask_threshold_mode_combo.currentText()
+        )
+        self._update_mask_sigma_units_label()
 
     def _setup_viz_tab(self, parent: QWidget) -> None:
         """Set up the visualization settings tab."""
@@ -555,6 +722,7 @@ class NeuronViewerWidget(QWidget):
 
             self._query_btn.setEnabled(True)
             self._analysis_tab.set_database(self._db)
+            self._regions_status_label.setText("")
             logger.info(f"Loaded Parquet file: {filepath}")
 
         except Exception as e:
@@ -576,11 +744,15 @@ class NeuronViewerWidget(QWidget):
                 f"Atlas: {atlas_name} ({len(self._atlas.structures)} structures)"
             )
             self._analysis_tab.set_atlas(self._atlas)
+            self._update_mask_sigma_units_label()
+            self._refresh_heatmap_layer_list()
+            self._refresh_mask_layer_options()
             logger.info(f"Loaded atlas: {atlas_name}")
 
         except Exception as e:
             logger.error(f"Failed to load atlas: {e}")
             self._atlas_status_label.setText(f"Atlas: Error - {e}")
+            self._update_mask_sigma_units_label()
 
     def _import_point_parquet(self) -> None:
         """Open file dialog and import standardized point Parquet."""
@@ -654,6 +826,10 @@ class NeuronViewerWidget(QWidget):
                     "nonzero_voxels": nonzero_voxels,
                     "columns": list(label_df.columns),
                     "color": rgba,
+                    "heatmap_source": True,
+                    "heatmap_native_grid": True,
+                    "atlas_name": getattr(self._atlas, "atlas_name", None),
+                    "heatmap_kind": "point_import",
                 },
             )
 
@@ -674,6 +850,344 @@ class NeuronViewerWidget(QWidget):
             len(label_heatmaps),
             len(points_df),
         )
+        self._refresh_heatmap_layer_list()
+        self._refresh_mask_layer_options()
+
+    def _connect_layer_events(self) -> None:
+        """Refresh tool and mask selectors when viewer layers change."""
+        layer_events = getattr(getattr(self.viewer, "layers", None), "events", None)
+        if layer_events is None:
+            return
+        for event_name in ("inserted", "removed", "reordered"):
+            signal = getattr(layer_events, event_name, None)
+            if signal is not None:
+                signal.connect(self._on_viewer_layers_changed)
+
+    def _on_viewer_layers_changed(self, _event=None) -> None:
+        """Refresh UI that depends on viewer layers."""
+        self._refresh_heatmap_layer_list()
+        self._refresh_mask_layer_options()
+
+    def _iter_viewer_layers(self) -> list:
+        """Return current viewer layers as a list."""
+        try:
+            return list(self.viewer.layers)
+        except Exception:
+            return []
+
+    def _current_atlas_name(self) -> str | None:
+        """Return the currently loaded atlas name, if any."""
+        if self._atlas is None:
+            return None
+        return str(getattr(self._atlas, "atlas_name", "")) or None
+
+    def _update_mask_sigma_units_label(self) -> None:
+        """Show Gaussian sigma units in voxels with atlas micron equivalence."""
+        if not hasattr(self, "_mask_sigma_units_label"):
+            return
+
+        if self._atlas is None:
+            self._mask_sigma_units_label.setText(
+                "Sigma is measured in atlas voxels. Load an atlas to see the micron equivalent."
+            )
+            return
+
+        resolution = np.asarray(self._atlas.resolution, dtype=float)
+        if np.allclose(resolution, resolution[0]):
+            self._mask_sigma_units_label.setText(
+                f"Sigma is measured in atlas voxels. "
+                f"With the current atlas, 1 voxel = {resolution[0]:g} µm."
+            )
+        else:
+            self._mask_sigma_units_label.setText(
+                "Sigma is measured in atlas voxels. "
+                f"With the current atlas, 1 voxel = "
+                f"{resolution[2]:g} µm (X), {resolution[1]:g} µm (Y), "
+                f"{resolution[0]:g} µm (Z)."
+            )
+
+    def _heatmap_layer_eligibility(self, layer) -> tuple[bool, str]:
+        """Return whether a layer is eligible as a Tools heatmap source."""
+        if self._atlas is None:
+            return False, "Load an atlas to select heatmaps."
+
+        metadata = _layer_metadata(layer)
+        if not metadata.get("heatmap_source"):
+            return False, "Not an app heatmap layer."
+        if not metadata.get("heatmap_native_grid", False):
+            return False, "Heatmap is not on the native atlas voxel grid."
+        if metadata.get("atlas_name") != self._current_atlas_name():
+            return False, "Heatmap atlas does not match the loaded atlas."
+
+        data = np.asarray(getattr(layer, "data", np.array([])))
+        atlas_shape = tuple(np.asarray(self._atlas.annotation).shape)
+        if data.ndim != 3 or tuple(data.shape) != atlas_shape:
+            return False, "Heatmap shape does not match the loaded atlas."
+        return True, ""
+
+    def _generated_mask_layers(self) -> list:
+        """Return generated mask layers eligible for Regions queries."""
+        masks = []
+        atlas_name = self._current_atlas_name()
+        for layer in self._iter_viewer_layers():
+            metadata = _layer_metadata(layer)
+            if not metadata.get("mask_query_source"):
+                continue
+            if atlas_name is not None and metadata.get("atlas_name") != atlas_name:
+                continue
+            masks.append(layer)
+        return masks
+
+    def _refresh_heatmap_layer_list(self) -> None:
+        """Refresh the Tools heatmap selector list."""
+        if not hasattr(self, "_heatmap_layer_list"):
+            return
+
+        previous = {
+            item.text()
+            for item in self._heatmap_layer_list.selectedItems()
+        }
+        self._heatmap_layer_list.clear()
+
+        eligible_names: list[str] = []
+        excluded_messages: list[str] = []
+        for layer in self._iter_viewer_layers():
+            eligible, reason = self._heatmap_layer_eligibility(layer)
+            if eligible:
+                self._heatmap_layer_list.addItem(layer.name)
+                eligible_names.append(layer.name)
+            elif _layer_metadata(layer).get("heatmap_source"):
+                excluded_messages.append(f"{layer.name}: {reason}")
+
+        for index in range(self._heatmap_layer_list.count()):
+            item = self._heatmap_layer_list.item(index)
+            if item.text() in previous:
+                item.setSelected(True)
+
+        if not eligible_names:
+            if excluded_messages:
+                self._tools_hint_label.setText(
+                    "No eligible native-grid heatmaps. "
+                    + " ".join(excluded_messages[:3])
+                )
+            else:
+                self._tools_hint_label.setText(
+                    "No eligible heatmap layers are available."
+                )
+        elif excluded_messages:
+            self._tools_hint_label.setText(
+                f"{len(eligible_names)} eligible heatmap layer(s). "
+                + "Excluded: "
+                + "; ".join(excluded_messages[:3])
+            )
+        else:
+            self._tools_hint_label.setText(
+                f"{len(eligible_names)} eligible heatmap layer(s)."
+            )
+
+    def _refresh_mask_layer_options(self) -> None:
+        """Refresh Regions-tab mask layer options."""
+        if not hasattr(self, "_mask_layer_selector"):
+            return
+
+        masks = self._generated_mask_layers()
+        mask_entries = []
+        for layer in masks:
+            metadata = _layer_metadata(layer)
+            mask_entries.append(
+                {
+                    "name": layer.name,
+                    "sources": metadata.get("source_heatmap_layers", []),
+                }
+            )
+        self._mask_layer_selector.set_mask_layers(mask_entries)
+        hint = (
+            f"{len(masks)} generated mask layer(s) available."
+            if masks
+            else "No generated mask layers are available."
+        )
+        self._mask_query_hint_label.setText(hint)
+
+    def _on_mask_threshold_mode_changed(self, text: str) -> None:
+        """Enable manual threshold input only for manual mode."""
+        if hasattr(self, "_mask_manual_threshold_spin"):
+            self._mask_manual_threshold_spin.setEnabled(text == "Manual")
+
+    def _selected_heatmap_layers(self) -> list:
+        """Return selected eligible heatmap layers from the Tools tab."""
+        selected_names = {
+            item.text() for item in self._heatmap_layer_list.selectedItems()
+        }
+        if not selected_names:
+            return []
+        layers = []
+        for layer in self._iter_viewer_layers():
+            if layer.name in selected_names and self._heatmap_layer_eligibility(layer)[0]:
+                layers.append(layer)
+        return layers
+
+    def _selected_mask_query_layers(self) -> list:
+        """Return the currently selected generated mask layers."""
+        if not hasattr(self, "_mask_layer_selector"):
+            return []
+        names = set(self._mask_layer_selector.get_selected_layer_names())
+        if not names:
+            return []
+        return [
+            layer for layer in self._generated_mask_layers()
+            if layer.name in names
+        ]
+
+    def _on_mask_layer_selection_changed(self, selected_names: list[str]) -> None:
+        """Update Regions status text when mask selection changes."""
+        count = len(selected_names)
+        if count == 0:
+            self._regions_status_label.setText("")
+        elif count == 1:
+            self._regions_status_label.setText("1 mask layer selected for querying.")
+        else:
+            self._regions_status_label.setText(
+                f"{count} mask layers selected for querying."
+            )
+
+    def _create_masks_from_heatmaps(self) -> None:
+        """Create binary mask label layers from selected heatmap image layers."""
+        if self._atlas is None:
+            message = "Load an atlas before creating mask layers."
+            self._tools_status_label.setText(message)
+            show_warning(message)
+            return
+
+        selected_layers = self._selected_heatmap_layers()
+        if not selected_layers:
+            message = "Select at least one eligible heatmap layer."
+            self._tools_status_label.setText(message)
+            return
+
+        sigma = float(self._mask_sigma_spin.value())
+        threshold_mode = self._mask_threshold_mode_combo.currentText().strip().lower()
+        manual_threshold = None
+        if threshold_mode == "manual":
+            manual_threshold = float(self._mask_manual_threshold_spin.value())
+
+        output_mode = self._mask_output_mode_combo.currentText()
+        created_layers = []
+
+        if output_mode == "Merged mask":
+            merged_volume = merge_heatmap_volumes(
+                [np.asarray(layer.data, dtype=np.float32) for layer in selected_layers]
+            )
+            mask, threshold, _smoothed = build_binary_mask_from_heatmap(
+                merged_volume,
+                sigma=sigma,
+                threshold_mode=threshold_mode,
+                manual_threshold=manual_threshold,
+            )
+            layer_name = f"Mask: merged {len(selected_layers)} heatmaps"
+            created_layers.append(
+                self._add_mask_layer(
+                    layer_name=layer_name,
+                    mask=mask,
+                    source_layers=selected_layers,
+                    sigma=sigma,
+                    threshold_mode=threshold_mode,
+                    threshold=threshold,
+                    merge_mode="merged_sum",
+                )
+            )
+        else:
+            for layer in selected_layers:
+                mask, threshold, _smoothed = build_binary_mask_from_heatmap(
+                    np.asarray(layer.data, dtype=np.float32),
+                    sigma=sigma,
+                    threshold_mode=threshold_mode,
+                    manual_threshold=manual_threshold,
+                )
+                created_layers.append(
+                    self._add_mask_layer(
+                        layer_name=f"Mask: {layer.name}",
+                        mask=mask,
+                        source_layers=[layer],
+                        sigma=sigma,
+                        threshold_mode=threshold_mode,
+                        threshold=threshold,
+                        merge_mode="separate",
+                    )
+                )
+
+        nonempty = sum(int(np.asarray(layer.data).sum() > 0) for layer in created_layers)
+        self._tools_status_label.setText(
+            f"Created {len(created_layers)} mask layer(s); {nonempty} contain nonzero voxels."
+        )
+        self._refresh_mask_layer_options()
+
+    def _add_mask_layer(
+        self,
+        layer_name: str,
+        mask: np.ndarray,
+        source_layers: list,
+        sigma: float,
+        threshold_mode: str,
+        threshold: float,
+        merge_mode: str,
+    ):
+        """Add or replace a generated binary mask layer."""
+        from napari.utils import DirectLabelColormap
+
+        for layer in list(self._iter_viewer_layers()):
+            if layer.name == layer_name:
+                self.viewer.layers.remove(layer)
+
+        labels = np.asarray(mask, dtype=np.uint8)
+        rgba = _mask_layer_color(source_layers)
+        color_dict = {
+            None: np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            0: np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        }
+        color_dict[1] = np.array(
+            rgba if rgba is not None else (0.8, 0.8, 0.8, 1.0),
+            dtype=np.float32,
+        )
+
+        layer = self.viewer.add_labels(
+            labels,
+            name=layer_name,
+            opacity=self._opacity_slider.value() / 100.0,
+            visible=True,
+            colormap=DirectLabelColormap(color_dict=color_dict),
+            metadata={
+                "mask_query_source": True,
+                "source_heatmap_layers": [layer.name for layer in source_layers],
+                "sigma": sigma,
+                "threshold_mode": threshold_mode,
+                "threshold_value": float(threshold),
+                "merge_mode": merge_mode,
+                "atlas_name": self._current_atlas_name(),
+                "color": rgba,
+            },
+        )
+        return layer
+
+    def _on_region_query_source_changed(self, text: str) -> None:
+        """Switch Regions tab between atlas and mask query modes."""
+        self._region_query_source = text
+        if not hasattr(self, "_region_query_stack"):
+            return
+
+        if text == "Mask Layer":
+            self._region_query_stack.setCurrentIndex(1)
+            self._query_btn.setText("Find Neurons in Selected Mask Layers")
+        else:
+            self._region_query_stack.setCurrentIndex(0)
+            self._query_btn.setText("Find Neurons in Selected Regions")
+        self._regions_status_label.setText("")
+
+    def _query_neurons(self) -> None:
+        """Dispatch Regions-tab queries by the selected source type."""
+        if self._region_query_source == "Mask Layer":
+            self._query_neurons_by_mask()
+        else:
+            self._query_neurons_by_region()
 
     def _on_regions_selected(self, acronyms: list[str]) -> None:
         """Handle region selection changes."""
@@ -695,24 +1209,66 @@ class NeuronViewerWidget(QWidget):
 
         acronyms = self._region_selector.get_selected_acronyms(include_children=True)
         if not acronyms:
+            self._regions_status_label.setText("Select at least one atlas region.")
             return
 
         try:
             result = self._db.get_neurons_by_region(acronyms)
-
-            # Populate neuron table
-            neurons = [
-                (row["file_id"], row["subject"])
-                for _, row in result.iterrows()
-            ]
-            self._neuron_table.populate(neurons)
-            self._neuron_table.set_added_file_ids(set())
-            self._refresh_cluster_filter_controls()
-
+            self._populate_neuron_table(result)
+            self._regions_status_label.setText(
+                f"Found {len(result)} neuron(s) in selected atlas regions."
+            )
             logger.info(f"Found {len(result)} neurons in selected regions")
 
         except Exception as e:
             logger.error(f"Query failed: {e}")
+
+    def _query_neurons_by_mask(self) -> None:
+        """Query neurons using a generated mask layer."""
+        if self._db is None or self._atlas is None:
+            return
+
+        layers = self._selected_mask_query_layers()
+        if not layers:
+            self._regions_status_label.setText("Select at least one generated mask layer.")
+            return
+
+        mask = np.logical_or.reduce([np.asarray(layer.data) > 0 for layer in layers])
+        if not mask.any():
+            message = "Selected mask layer selection is empty and cannot be queried."
+            self._regions_status_label.setText(message)
+            show_warning(message)
+            return
+
+        soma_only = bool(self._mask_query_membership_combo.currentData())
+        try:
+            result = self._db.get_neurons_by_mask(mask, self._atlas, soma_only=soma_only)
+            self._populate_neuron_table(result)
+            mode = "somas" if soma_only else "nodes"
+            selected_names = ", ".join(layer.name for layer in layers[:3])
+            if len(layers) > 3:
+                selected_names += ", ..."
+            self._regions_status_label.setText(
+                f"Found {len(result)} neuron(s) with {mode} in {len(layers)} selected mask layer(s): {selected_names}"
+            )
+            logger.info(
+                "Found %d neurons in %d selected mask layers",
+                len(result),
+                len(layers),
+            )
+        except Exception as e:
+            logger.error(f"Mask query failed: {e}")
+            self._regions_status_label.setText(f"Mask query failed: {e}")
+
+    def _populate_neuron_table(self, result) -> None:
+        """Populate the neuron table from a query result."""
+        neurons = [
+            (row["file_id"], row["subject"])
+            for _, row in result.iterrows()
+        ]
+        self._neuron_table.populate(neurons)
+        self._neuron_table.set_added_file_ids(set())
+        self._refresh_cluster_filter_controls()
 
     def _selected_cluster_from_filter(self) -> int | None:
         """Return selected cluster from the Data tab dropdown."""

--- a/src/napari_swc_viewer/widgets/neuron_viewer.py
+++ b/src/napari_swc_viewer/widgets/neuron_viewer.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from brainglobe_atlasapi import BrainGlobeAtlas
-from napari.utils.notifications import show_info
+from napari.utils.notifications import show_info, show_warning
 from qtpy.QtCore import Qt, QThread, QTimer
 from qtpy.QtWidgets import (
     QApplication,
@@ -40,6 +40,13 @@ from ..auto_center import (
     depth_axis_from_not_displayed,
 )
 from ..db import NeuronDatabase
+from ..point_import import (
+    PointImportError,
+    dataframe_to_point_properties,
+    format_atlas_validation_summary,
+    load_standard_point_parquet,
+    validate_point_metadata_against_atlas,
+)
 from .reference_layers import (
     add_allen_template,
     add_brain_outline,
@@ -216,6 +223,26 @@ class NeuronViewerWidget(QWidget):
         # Atlas status label
         self._atlas_status_label = QLabel("Atlas: Not loaded")
         layout.addWidget(self._atlas_status_label)
+
+        # Standardized point Parquet import
+        point_group = QGroupBox("Point Parquet Import")
+        point_layout = QVBoxLayout(point_group)
+
+        point_row = QHBoxLayout()
+        self._point_file_label = QLabel("No point parquet imported")
+        self._point_file_label.setWordWrap(True)
+        point_row.addWidget(self._point_file_label)
+
+        import_point_btn = QPushButton("Import Point Parquet...")
+        import_point_btn.clicked.connect(self._import_point_parquet)
+        point_row.addWidget(import_point_btn)
+        point_layout.addLayout(point_row)
+
+        self._point_import_status_label = QLabel("")
+        self._point_import_status_label.setWordWrap(True)
+        point_layout.addWidget(self._point_import_status_label)
+
+        layout.addWidget(point_group)
 
         # Selected neurons table
         neurons_group = QGroupBox("Selected Neurons")
@@ -531,6 +558,87 @@ class NeuronViewerWidget(QWidget):
         except Exception as e:
             logger.error(f"Failed to load atlas: {e}")
             self._atlas_status_label.setText(f"Atlas: Error - {e}")
+
+    def _import_point_parquet(self) -> None:
+        """Open file dialog and import standardized point Parquet."""
+        filepath, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Point Parquet File",
+            "",
+            "Parquet Files (*.parquet);;All Files (*)",
+        )
+        if not filepath:
+            return
+
+        self._load_point_parquet_file(filepath)
+
+    def _load_point_parquet_file(self, filepath: str) -> None:
+        """Load standardized point Parquet and add one layer per label."""
+        if self._atlas is None:
+            message = "Load an atlas before importing point Parquet."
+            self._point_import_status_label.setText(message)
+            show_warning(message)
+            return
+
+        try:
+            points_df = load_standard_point_parquet(filepath)
+        except PointImportError as e:
+            logger.error(f"Failed to load point Parquet: {e}")
+            self._point_import_status_label.setText(f"Error: {e}")
+            return
+
+        if points_df.empty:
+            self._point_file_label.setText(Path(filepath).name)
+            self._point_import_status_label.setText("No points found in file.")
+            return
+
+        validation_summary = validate_point_metadata_against_atlas(
+            points_df,
+            self._atlas,
+        )
+        if validation_summary.has_mismatches:
+            show_warning(format_atlas_validation_summary(validation_summary))
+
+        scale = [1.0 / res for res in self._atlas.resolution]
+        opacity = self._opacity_slider.value() / 100.0
+        label_order = list(dict.fromkeys(points_df["label"].tolist()))
+
+        for label in label_order:
+            label_df = points_df.loc[points_df["label"] == label]
+            coords = label_df[["x", "y", "z"]].to_numpy(dtype=float, copy=False)
+            properties = dataframe_to_point_properties(label_df)
+
+            self.viewer.add_points(
+                coords,
+                size=self._point_size_spin.value(),
+                name=f"Points: {label}",
+                opacity=opacity,
+                scale=scale,
+                properties=properties,
+                metadata={
+                    "source_path": filepath,
+                    "label": label,
+                    "point_count": len(label_df),
+                },
+            )
+
+        self._point_file_label.setText(Path(filepath).name)
+        message = (
+            f"Imported {len(points_df):,} point(s) across {len(label_order)} "
+            f"label(s)."
+        )
+        if validation_summary.has_mismatches:
+            message += (
+                f" Atlas validation found "
+                f"{validation_summary.total_mismatched_rows} mismatched row(s)."
+            )
+        self._point_import_status_label.setText(message)
+        logger.info(
+            "Imported point Parquet %s with %d labels and %d points",
+            filepath,
+            len(label_order),
+            len(points_df),
+        )
 
     def _on_regions_selected(self, acronyms: list[str]) -> None:
         """Handle region selection changes."""

--- a/tests/test_point_import.py
+++ b/tests/test_point_import.py
@@ -85,6 +85,14 @@ class _DummyImageLayer:
         self.metadata = kwargs.get("metadata", {})
 
 
+class _DummyLabelsLayer:
+    def __init__(self, data: np.ndarray, **kwargs) -> None:
+        self.data = np.asarray(data)
+        self.name = kwargs["name"]
+        self.opacity = kwargs.get("opacity")
+        self.metadata = kwargs.get("metadata", {})
+
+
 class _DummyViewer:
     def __init__(self) -> None:
         self.layers: list[_DummyPointsLayer] = []
@@ -97,6 +105,11 @@ class _DummyViewer:
 
     def add_image(self, data: np.ndarray, **kwargs) -> _DummyImageLayer:
         layer = _DummyImageLayer(data, **kwargs)
+        self.layers.append(layer)
+        return layer
+
+    def add_labels(self, data: np.ndarray, **kwargs) -> _DummyLabelsLayer:
+        layer = _DummyLabelsLayer(data, **kwargs)
         self.layers.append(layer)
         return layer
 

--- a/tests/test_point_import.py
+++ b/tests/test_point_import.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from napari_swc_viewer.point_import import (
+    PointImportError,
+    convert_point_csv_to_parquet,
+    format_atlas_validation_summary,
+    load_column_mapping,
+    load_standard_point_parquet,
+    standardize_point_dataframe,
+    validate_point_metadata_against_atlas,
+)
+
+
+class FakeAtlas:
+    def __init__(self) -> None:
+        self.annotation = np.zeros((5, 5, 5), dtype=np.int32)
+        self.annotation[4, 3, 2] = 101
+        self.annotation[2, 2, 1] = 202
+        self.resolution = (25.0, 25.0, 25.0)
+        self.shape = self.annotation.shape
+        self.atlas_name = "fake_atlas"
+        self.structures = {
+            101: {"name": "Region, One", "acronym": "R1"},
+            202: {"name": "Region Two", "acronym": "R2"},
+        }
+
+
+@pytest.fixture
+def fake_atlas() -> FakeAtlas:
+    return FakeAtlas()
+
+
+class _DummyEvent:
+    def connect(self, *_args, **_kwargs) -> None:
+        return None
+
+    def disconnect(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _DummyDims:
+    def __init__(self) -> None:
+        self.ndisplay = 3
+        self.not_displayed = (0,)
+        self.point = (0.0, 0.0, 0.0)
+        self.order = (0, 1, 2)
+        self.events = types.SimpleNamespace(
+            ndisplay=_DummyEvent(),
+            order=_DummyEvent(),
+            current_step=_DummyEvent(),
+        )
+
+
+class _DummyPointsLayer:
+    def __init__(self, data: np.ndarray, **kwargs) -> None:
+        self.data = np.asarray(data)
+        self.name = kwargs["name"]
+        self.scale = np.asarray(kwargs.get("scale"))
+        self.properties = {
+            key: np.asarray(value, dtype=object)
+            for key, value in kwargs.get("properties", {}).items()
+        }
+        self.metadata = kwargs.get("metadata", {})
+
+
+class _DummyViewer:
+    def __init__(self) -> None:
+        self.layers: list[_DummyPointsLayer] = []
+        self.dims = _DummyDims()
+
+    def add_points(self, data: np.ndarray, **kwargs) -> _DummyPointsLayer:
+        layer = _DummyPointsLayer(data, **kwargs)
+        self.layers.append(layer)
+        return layer
+
+
+def _import_neuron_viewer_widget():
+    import importlib
+
+    from qtpy.QtWidgets import QApplication, QWidget
+
+    app = QApplication.instance()
+    if app is None:
+        QApplication([])
+
+    class _DummySignal:
+        def connect(self, *_args, **_kwargs) -> None:
+            return None
+
+    class _FakeAnalysisTabWidget(QWidget):
+        def __init__(self, *_args, **_kwargs) -> None:
+            super().__init__()
+            self.cluster_colors_updated = _DummySignal()
+
+        def set_slice_projector(self, *_args, **_kwargs) -> None:
+            return None
+
+        def set_database(self, *_args, **_kwargs) -> None:
+            return None
+
+        def set_atlas(self, *_args, **_kwargs) -> None:
+            return None
+
+        def apply_cluster_colors(self) -> None:
+            return None
+
+    fake_analysis_module = types.ModuleType(
+        "napari_swc_viewer.widgets.analysis_tab"
+    )
+    fake_analysis_module.AnalysisTabWidget = _FakeAnalysisTabWidget
+    sys.modules["napari_swc_viewer.widgets.analysis_tab"] = fake_analysis_module
+    sys.modules.pop("napari_swc_viewer.widgets.neuron_viewer", None)
+    sys.modules.pop("napari_swc_viewer.widgets", None)
+
+    module = importlib.import_module("napari_swc_viewer.widgets.neuron_viewer")
+    return module.NeuronViewerWidget
+
+
+def test_load_column_mapping_requires_required_targets(tmp_path: Path) -> None:
+    mapping_path = tmp_path / "mapping.json"
+    mapping_path.write_text(json.dumps({"label": "marker", "x": "atlas_x"}))
+
+    with pytest.raises(PointImportError, match="Missing required mapping"):
+        load_column_mapping(mapping_path)
+
+
+def test_convert_point_csv_to_parquet_preserves_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "points.csv"
+    mapping_path = tmp_path / "mapping.json"
+    output_path = tmp_path / "points.parquet"
+
+    pd.DataFrame(
+        {
+            "marker": ["A", "B"],
+            "atlas_x": [50.0, 25.0],
+            "atlas_y": [75.0, 50.0],
+            "atlas_z": [100.0, 50.0],
+            "score": [0.5, 0.9],
+            "region_acronym": ["R1", "R2"],
+        }
+    ).to_csv(csv_path, index=False)
+    mapping_path.write_text(
+        json.dumps(
+            {
+                "label": "marker",
+                "x": "atlas_x",
+                "y": "atlas_y",
+                "z": "atlas_z",
+                "acronym": "region_acronym",
+            }
+        )
+    )
+
+    standardized = convert_point_csv_to_parquet(csv_path, mapping_path, output_path)
+    loaded = pd.read_parquet(output_path)
+
+    assert list(standardized.columns) == [
+        "label",
+        "x",
+        "y",
+        "z",
+        "region_name",
+        "acronym",
+        "id",
+        "hemisphere",
+        "score",
+    ]
+    assert list(loaded.columns) == list(standardized.columns)
+    assert loaded["score"].tolist() == [0.5, 0.9]
+    assert loaded["acronym"].tolist() == ["R1", "R2"]
+    assert loaded["region_name"].isna().all()
+
+
+def test_convert_point_csv_to_parquet_rejects_invalid_coordinates(
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "points.csv"
+    mapping_path = tmp_path / "mapping.json"
+    output_path = tmp_path / "points.parquet"
+
+    pd.DataFrame(
+        {
+            "marker": ["A"],
+            "atlas_x": ["bad"],
+            "atlas_y": [75.0],
+            "atlas_z": [100.0],
+        }
+    ).to_csv(csv_path, index=False)
+    mapping_path.write_text(
+        json.dumps(
+            {"label": "marker", "x": "atlas_x", "y": "atlas_y", "z": "atlas_z"}
+        )
+    )
+
+    with pytest.raises(PointImportError, match="Column 'x' has 1 invalid value"):
+        convert_point_csv_to_parquet(csv_path, mapping_path, output_path)
+
+
+def test_validate_point_metadata_against_atlas_uses_world_xyz_order(
+    fake_atlas: FakeAtlas,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "label": ["A"],
+            "x": [50.0],
+            "y": [75.0],
+            "z": [100.0],
+            "region_name": ["Region/One"],
+            "acronym": ["R1"],
+            "id": [101],
+            "hemisphere": ["right"],
+        }
+    )
+
+    summary = validate_point_metadata_against_atlas(df, fake_atlas)
+
+    assert not summary.has_mismatches
+    assert summary.checked_fields == ("id", "acronym", "region_name", "hemisphere")
+
+
+def test_validate_point_metadata_against_atlas_reports_field_counts(
+    fake_atlas: FakeAtlas,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "label": ["A"],
+            "x": [50.0],
+            "y": [75.0],
+            "z": [100.0],
+            "region_name": ["Wrong Region"],
+            "acronym": ["BAD"],
+            "id": [999],
+            "hemisphere": ["left"],
+        }
+    )
+
+    summary = validate_point_metadata_against_atlas(df, fake_atlas)
+    message = format_atlas_validation_summary(summary)
+
+    assert summary.total_mismatched_rows == 1
+    assert summary.mismatch_counts == {
+        "id": 1,
+        "acronym": 1,
+        "region_name": 1,
+        "hemisphere": 1,
+    }
+    assert "row 1 label=A" in message
+
+
+def test_standardize_point_dataframe_rejects_conflicting_extra_columns() -> None:
+    raw_df = pd.DataFrame(
+        {
+            "marker": ["A"],
+            "atlas_x": [1.0],
+            "atlas_y": [2.0],
+            "atlas_z": [3.0],
+            "label": ["conflict"],
+        }
+    )
+
+    with pytest.raises(PointImportError, match="conflict with standardized"):
+        standardize_point_dataframe(
+            raw_df,
+            {"label": "marker", "x": "atlas_x", "y": "atlas_y", "z": "atlas_z"},
+        )
+
+
+def test_convert_point_csv_script(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    csv_path = tmp_path / "points.csv"
+    mapping_path = tmp_path / "mapping.json"
+    output_path = tmp_path / "points.parquet"
+
+    pd.DataFrame(
+        {
+            "marker": ["A"],
+            "atlas_x": [50.0],
+            "atlas_y": [75.0],
+            "atlas_z": [100.0],
+        }
+    ).to_csv(csv_path, index=False)
+    mapping_path.write_text(
+        json.dumps(
+            {"label": "marker", "x": "atlas_x", "y": "atlas_y", "z": "atlas_z"}
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/convert_point_csv.py",
+            str(csv_path),
+            str(mapping_path),
+            str(output_path),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    loaded = load_standard_point_parquet(output_path)
+    assert loaded["label"].tolist() == ["A"]
+
+
+@pytest.mark.skip(reason="Qt runtime is unavailable in the current test sandbox.")
+def test_widget_import_point_parquet_requires_loaded_atlas(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    NeuronViewerWidget = _import_neuron_viewer_widget()
+    monkeypatch.setattr(NeuronViewerWidget, "_toggle_template", lambda self, state: None)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "napari_swc_viewer.widgets.neuron_viewer.show_warning",
+        lambda message: warnings.append(message),
+    )
+
+    viewer = _DummyViewer()
+    widget = NeuronViewerWidget(viewer)
+
+    parquet_path = tmp_path / "points.parquet"
+    pd.DataFrame({"label": ["A"], "x": [1.0], "y": [2.0], "z": [3.0]}).to_parquet(
+        parquet_path,
+        index=False,
+    )
+
+    widget._load_point_parquet_file(str(parquet_path))
+
+    assert warnings == ["Load an atlas before importing point Parquet."]
+    assert widget._point_import_status_label.text() == (
+        "Load an atlas before importing point Parquet."
+    )
+    assert len(viewer.layers) == 0
+
+
+@pytest.mark.skip(reason="Qt runtime is unavailable in the current test sandbox.")
+def test_widget_import_point_parquet_creates_layers_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_atlas: FakeAtlas,
+) -> None:
+    NeuronViewerWidget = _import_neuron_viewer_widget()
+    monkeypatch.setattr(NeuronViewerWidget, "_toggle_template", lambda self, state: None)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "napari_swc_viewer.widgets.neuron_viewer.show_warning",
+        lambda message: warnings.append(message),
+    )
+
+    viewer = _DummyViewer()
+    widget = NeuronViewerWidget(viewer)
+    widget._atlas = fake_atlas
+
+    parquet_path = tmp_path / "points.parquet"
+    pd.DataFrame(
+        {
+            "label": ["A", "A", "B"],
+            "x": [50.0, 25.0, 50.0],
+            "y": [75.0, 50.0, 75.0],
+            "z": [100.0, 50.0, 100.0],
+            "region_name": ["Region/One", pd.NA, "Wrong Region"],
+            "acronym": ["R1", pd.NA, "BAD"],
+            "id": [101, pd.NA, 999],
+            "hemisphere": ["right", pd.NA, "left"],
+            "score": [0.1, 0.2, 0.3],
+        }
+    ).to_parquet(parquet_path, index=False)
+
+    widget._load_point_parquet_file(str(parquet_path))
+
+    layer_names = [layer.name for layer in viewer.layers]
+    assert layer_names == ["Points: A", "Points: B"]
+    assert warnings
+    assert "mismatched point(s)" in warnings[0]
+    assert "3 point(s) across 2 label(s)" in widget._point_import_status_label.text()
+    assert "mismatched row(s)" in widget._point_import_status_label.text()
+
+    layer_a = viewer.layers[0]
+    assert np.allclose(layer_a.scale, [1 / 25.0, 1 / 25.0, 1 / 25.0])
+    assert list(layer_a.properties["score"]) == [0.1, 0.2]
+    assert list(layer_a.properties["acronym"]) == ["R1", None]

--- a/tests/test_point_import.py
+++ b/tests/test_point_import.py
@@ -14,6 +14,7 @@ import pytest
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from napari_swc_viewer.point_import import (
+    build_label_heatmap_volumes,
     PointImportError,
     convert_point_csv_to_parquet,
     format_atlas_validation_summary,
@@ -76,6 +77,14 @@ class _DummyPointsLayer:
         self.metadata = kwargs.get("metadata", {})
 
 
+class _DummyImageLayer:
+    def __init__(self, data: np.ndarray, **kwargs) -> None:
+        self.data = np.asarray(data)
+        self.name = kwargs["name"]
+        self.opacity = kwargs.get("opacity")
+        self.metadata = kwargs.get("metadata", {})
+
+
 class _DummyViewer:
     def __init__(self) -> None:
         self.layers: list[_DummyPointsLayer] = []
@@ -83,6 +92,11 @@ class _DummyViewer:
 
     def add_points(self, data: np.ndarray, **kwargs) -> _DummyPointsLayer:
         layer = _DummyPointsLayer(data, **kwargs)
+        self.layers.append(layer)
+        return layer
+
+    def add_image(self, data: np.ndarray, **kwargs) -> _DummyImageLayer:
+        layer = _DummyImageLayer(data, **kwargs)
         self.layers.append(layer)
         return layer
 
@@ -260,6 +274,28 @@ def test_validate_point_metadata_against_atlas_reports_field_counts(
     assert "row 1 label=A" in message
 
 
+def test_build_label_heatmap_volumes_groups_counts_by_label(
+    fake_atlas: FakeAtlas,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "label": ["A", "A", "B"],
+            "x": [50.0, 50.0, 25.0],
+            "y": [75.0, 75.0, 50.0],
+            "z": [100.0, 100.0, 50.0],
+        }
+    )
+
+    volumes = build_label_heatmap_volumes(df, fake_atlas)
+
+    assert set(volumes) == {"A", "B"}
+    assert volumes["A"].shape == fake_atlas.annotation.shape
+    assert float(volumes["A"][4, 3, 2]) == 2.0
+    assert float(volumes["B"][2, 2, 1]) == 1.0
+    assert int((volumes["A"] > 0).sum()) == 1
+    assert int((volumes["B"] > 0).sum()) == 1
+
+
 def test_standardize_point_dataframe_rejects_conflicting_extra_columns() -> None:
     raw_df = pd.DataFrame(
         {
@@ -385,13 +421,12 @@ def test_widget_import_point_parquet_creates_layers_and_warns(
     widget._load_point_parquet_file(str(parquet_path))
 
     layer_names = [layer.name for layer in viewer.layers]
-    assert layer_names == ["Points: A", "Points: B"]
+    assert layer_names == ["Points Heatmap: A", "Points Heatmap: B"]
     assert warnings
     assert "mismatched point(s)" in warnings[0]
-    assert "3 point(s) across 2 label(s)" in widget._point_import_status_label.text()
+    assert "3 point(s) into 2 heatmap layer(s)" in widget._point_import_status_label.text()
     assert "mismatched row(s)" in widget._point_import_status_label.text()
 
     layer_a = viewer.layers[0]
-    assert np.allclose(layer_a.scale, [1 / 25.0, 1 / 25.0, 1 / 25.0])
-    assert list(layer_a.properties["score"]) == [0.1, 0.2]
-    assert list(layer_a.properties["acronym"]) == ["R1", None]
+    assert float(layer_a.data[4, 3, 2]) == 2.0
+    assert layer_a.metadata["point_count"] == 2

--- a/tests/test_tools_masks.py
+++ b/tests/test_tools_masks.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from napari_swc_viewer.analysis.mask import (
+    build_binary_mask_from_heatmap,
+    merge_heatmap_volumes,
+    otsu_threshold_positive,
+    smooth_heatmap_volume,
+)
+from napari_swc_viewer.db import NeuronDatabase
+
+
+class FakeAtlas:
+    def __init__(self) -> None:
+        self.annotation = np.zeros((5, 5, 5), dtype=np.int32)
+        self.resolution = (25.0, 25.0, 25.0)
+        self.atlas_name = "fake_atlas"
+        self.structures = {}
+
+
+def test_smooth_heatmap_volume_sigma_zero_returns_copy() -> None:
+    volume = np.zeros((3, 3, 3), dtype=np.float32)
+    volume[1, 1, 1] = 5.0
+
+    smoothed = smooth_heatmap_volume(volume, sigma=0.0)
+
+    assert np.array_equal(smoothed, volume)
+    assert smoothed is not volume
+
+
+def test_merge_heatmap_volumes_sums_inputs() -> None:
+    left = np.zeros((3, 3, 3), dtype=np.float32)
+    right = np.zeros((3, 3, 3), dtype=np.float32)
+    left[1, 1, 1] = 2.0
+    right[1, 1, 1] = 3.0
+    right[2, 1, 1] = 1.0
+
+    merged = merge_heatmap_volumes([left, right])
+
+    assert float(merged[1, 1, 1]) == 5.0
+    assert float(merged[2, 1, 1]) == 1.0
+
+
+def test_otsu_threshold_positive_ignores_zero_background() -> None:
+    volume = np.zeros((4, 4, 4), dtype=np.float32)
+    volume.ravel()[:4] = 1.0
+    volume.ravel()[4:8] = 10.0
+
+    threshold = otsu_threshold_positive(volume)
+
+    assert 1.0 <= threshold <= 10.0
+
+
+def test_build_binary_mask_from_heatmap_all_zero_volume_stays_empty() -> None:
+    volume = np.zeros((3, 3, 3), dtype=np.float32)
+
+    mask, threshold, smoothed = build_binary_mask_from_heatmap(
+        volume,
+        sigma=1.0,
+        threshold_mode="otsu",
+    )
+
+    assert threshold == 0.0
+    assert smoothed.shape == volume.shape
+    assert int(mask.sum()) == 0
+
+
+def test_build_binary_mask_from_heatmap_manual_threshold() -> None:
+    volume = np.zeros((3, 3, 3), dtype=np.float32)
+    volume[1, 1, 1] = 5.0
+    volume[1, 1, 2] = 1.0
+
+    mask, threshold, _smoothed = build_binary_mask_from_heatmap(
+        volume,
+        sigma=0.0,
+        threshold_mode="manual",
+        manual_threshold=2.0,
+    )
+
+    assert threshold == 2.0
+    assert int(mask[1, 1, 1]) == 1
+    assert int(mask[1, 1, 2]) == 0
+
+
+def test_get_neurons_by_mask_supports_any_node_and_soma_only(tmp_path: Path) -> None:
+    atlas = FakeAtlas()
+    parquet_path = tmp_path / "neurons.parquet"
+    df = pd.DataFrame(
+        {
+            "file_id": ["file_a", "file_a", "file_b", "file_c"],
+            "neuron_id": ["n1", "n1", "n2", "n3"],
+            "subject": ["s1", "s1", "s2", "s3"],
+            "node_id": [1, 2, 1, 1],
+            "parent_id": [-1, 1, -1, -1],
+            "x": [0.0, 50.0, 100.0, 75.0],
+            "y": [0.0, 75.0, 75.0, 75.0],
+            "z": [0.0, 100.0, 100.0, 100.0],
+            "type": [1, 2, 1, 1],
+            "region_id": [0, 0, 0, 0],
+            "region_name": ["", "", "", ""],
+            "region_acronym": ["", "", "", ""],
+        }
+    )
+    df.to_parquet(parquet_path, index=False)
+
+    mask = np.zeros(atlas.annotation.shape, dtype=np.uint8)
+    mask[4, 3, 2] = 1
+    mask[4, 3, 4] = 1
+
+    with NeuronDatabase(parquet_path) as db:
+        any_node = db.get_neurons_by_mask(mask, atlas, soma_only=False)
+        soma_only = db.get_neurons_by_mask(mask, atlas, soma_only=True)
+
+    assert any_node["file_id"].tolist() == ["file_a", "file_b"]
+    assert soma_only["file_id"].tolist() == ["file_b"]


### PR DESCRIPTION
## Summary
- add a shared point import pipeline for standardizing atlas-registered point CSVs into point Parquet
- add a repo conversion script for raw CSV + JSON mapping -> standardized Parquet
- add Data tab support for importing standardized point Parquet into one napari `Points` layer per label
- validate optional atlas metadata against the loaded atlas and warn on mismatches
- document the workflow and add point import tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pixi run pytest tests/test_import.py tests/test_point_import.py -q`
- `pixi run python -m compileall src scripts/convert_point_csv.py`

Closes #24
